### PR TITLE
fix: clear previous filters before applying new item filter

### DIFF
--- a/hooks/useItemFilterText.tsx
+++ b/hooks/useItemFilterText.tsx
@@ -1,4 +1,7 @@
-import { setJobSearchFilterData } from "@/lib/redux/features/filterJobs/filters";
+import {
+  clearAllFilters,
+  setJobSearchFilterData,
+} from "@/lib/redux/features/filterJobs/filters";
 import { AppDispatch } from "@/lib/redux/store";
 import { useDispatch } from "react-redux";
 import useJobFilter from "./useJobFilter";
@@ -12,6 +15,7 @@ const useItemFilterText = () => {
     isApplyJob: boolean,
     isApplyLocation: boolean
   ) => {
+    dispatch(clearAllFilters());
     dispatch(
       setJobSearchFilterData({
         filterItems: [item],


### PR DESCRIPTION
### What was fixed?
Previously, when applying a text filter by clicking on an item, the new filter was applied but the previous filter states were not cleared. This caused multiple filters to stack unintentionally.

### What changed?
- Added a call to `clearAllFilters()` before setting the new filter data.
- Ensures that old filters are cleared before applying the new filter.
- Keeps the filtering logic consistent and predictable.

### Code changes overview:
- Updated `useItemFilterText` hook to dispatch `clearAllFilters()` before `setJobSearchFilterData`.

### Impact:
- Filtering behavior is now reset correctly on each item filter application.
- Prevents unintended accumulation of filter states, improving user experience.