### PR TITLE
fix: resolve single open list bug and enhance filter menu UX

### DIFF
--- a/components/pages/jobPostings/filterMenu/CustomList.tsx
+++ b/components/pages/jobPostings/filterMenu/CustomList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AppDispatch, RootState } from "@/lib/redux/store";
-import React, { MouseEvent, useEffect, useState } from "react";
+import React, { MouseEvent, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { MdArrowDropDown } from "react-icons/md";
 import { IoIosClose } from "react-icons/io";
@@ -10,7 +10,7 @@ import { selectFiltersItem } from "@/lib/redux/features/filterJobs/filters";
 import useJobFilter from "@/hooks/useJobFilter";
 import { setTouchSortList } from "@/lib/redux/features/touch";
 
-const JobType = ({
+const CustomList = ({
   title,
   options,
   state,
@@ -19,30 +19,32 @@ const JobType = ({
   screenClass,
   listClass,
   listWrapperClass,
+  openCustomList,
+  setOpenCustomList,
 }: CustomListProps) => {
-  const [openJobMenu, setOpenJobMenu] = useState(false);
   const dispatch = useDispatch<AppDispatch>();
   const { filtersItem } = useSelector((state: RootState) => state.jobFilters);
   const { filterJob } = useJobFilter();
 
   useEffect(() => {
     window.addEventListener("click", () => {
-      setOpenJobMenu(false);
+      dispatch(setOpenCustomList(""));
       dispatch(setTouchSortList(false));
     });
-  }, [dispatch]);
+  }, [dispatch, setOpenCustomList]);
 
   const handleItemAction = (option: string): void => {
-    dispatch(setState(option));
-    setOpenJobMenu(false);
+    dispatch(setOpenCustomList(""));
 
     if (option !== "Sıralama (Varsayılan)" && option !== "Sayfa Başına 10") {
+      dispatch(setState(option));
       const updatedFilters = filtersItem.filter(
         (item) => !options.includes(item)
       );
 
       dispatch(selectFiltersItem([...updatedFilters, option]));
     } else {
+      dispatch(setState(""));
       dispatch(
         selectFiltersItem(filtersItem.filter((fi) => !options.includes(fi)))
       );
@@ -51,20 +53,29 @@ const JobType = ({
     filterJob();
   };
 
-  const handleClearCurrent = () => {
-    filterJob();
+  const handleClearCurrent = (e: MouseEvent<HTMLOrSVGElement>) => {
+    e.stopPropagation();
+    dispatch(setOpenCustomList(""));
 
     dispatch(setState(""));
-    dispatch(
-      selectFiltersItem(filtersItem.filter((item) => !options.includes(item)))
-    );
+    dispatch(selectFiltersItem(filtersItem.filter((item) => item !== state)));
+
+    filterJob();
   };
 
   const handleOpenList = (e: MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
-    setOpenJobMenu(!openJobMenu);
 
-    if (defaultValue.startsWith("Sıralama") && !openJobMenu) {
+    if (openCustomList === defaultValue) {
+      dispatch(setOpenCustomList(""));
+    } else {
+      dispatch(setOpenCustomList(defaultValue));
+    }
+
+    if (
+      defaultValue.startsWith("Sıralama") &&
+      openCustomList !== defaultValue
+    ) {
       dispatch(setTouchSortList(true));
     } else {
       dispatch(setTouchSortList(false));
@@ -78,7 +89,9 @@ const JobType = ({
       <div className="relative z-[1]">
         <div
           className={`job-type-screen ${screenClass} ${
-            openJobMenu ? "border-[#4045ef]" : "border-white"
+            openCustomList === defaultValue
+              ? "border-[#4045ef]"
+              : "border-white"
           }`}
           onClick={handleOpenList}
         >
@@ -95,12 +108,14 @@ const JobType = ({
 
             <MdArrowDropDown
               size={22}
-              className={openJobMenu ? "rotate-x-180" : "rotate-x-0"}
+              className={
+                openCustomList === defaultValue ? "rotate-x-180" : "rotate-x-0"
+              }
             />
           </div>
         </div>
 
-        {openJobMenu && (
+        {openCustomList === defaultValue && (
           <ul
             className={`job-type-list ${listClass}`}
             onClick={(e) => e.stopPropagation()}
@@ -121,4 +136,4 @@ const JobType = ({
   );
 };
 
-export default JobType;
+export default CustomList;

--- a/components/pages/jobPostings/filterMenu/FilterMenu.tsx
+++ b/components/pages/jobPostings/filterMenu/FilterMenu.tsx
@@ -17,11 +17,13 @@ import {
 } from "@/constants/filtersJob";
 import CustomButton from "@/components/ui/CustomButton";
 import useJobFilter from "@/hooks/useJobFilter";
+import { setOpenCustomList } from "@/lib/redux/features/touch";
 
 const FilterMenu = () => {
   const { experienceLevel, careerLevel, jobType } = useSelector(
     (state: RootState) => state.jobFilters
   );
+  const { openCustomList } = useSelector((state: RootState) => state.touch);
   const { filterJob, isLoading } = useJobFilter();
   const [isMobile, setIsMobile] = useState(false);
 
@@ -46,6 +48,8 @@ const FilterMenu = () => {
             setState={selectJobType}
             state={jobType}
             listWrapperClass="px-[30px] pt-[30px]"
+            openCustomList={openCustomList}
+            setOpenCustomList={setOpenCustomList}
           />
 
           <FilterSwitch

--- a/components/pages/jobPostings/filterMenu/FilterMenuMobile.tsx
+++ b/components/pages/jobPostings/filterMenu/FilterMenuMobile.tsx
@@ -20,6 +20,7 @@ import CustomButton from "@/components/ui/CustomButton";
 import useJobFilter from "@/hooks/useJobFilter";
 import { IoCloseOutline } from "react-icons/io5";
 import { CSSTransition } from "react-transition-group";
+import { setOpenCustomList } from "@/lib/redux/features/touch";
 
 const FilterMenuMobile = () => {
   const { experienceLevel, careerLevel, jobType, openfilterMenu } = useSelector(
@@ -28,6 +29,7 @@ const FilterMenuMobile = () => {
   const { filterJob, isLoading } = useJobFilter();
   const dispatch = useDispatch<AppDispatch>();
   const asideRef = useRef(null);
+  const { openCustomList } = useSelector((state: RootState) => state.touch);
 
   useEffect(() => {
     window.addEventListener("click", () => dispatch(openFilterMenu(false)));
@@ -71,6 +73,8 @@ const FilterMenuMobile = () => {
             state={jobType}
             listWrapperClass="px-[30px] pt-[30px]"
             screenClass="border !border-[#ECEDF2]"
+            openCustomList={openCustomList}
+            setOpenCustomList={setOpenCustomList}
           />
 
           <FilterSwitch

--- a/components/pages/jobPostings/jobs/JobItem.tsx
+++ b/components/pages/jobPostings/jobs/JobItem.tsx
@@ -1,5 +1,4 @@
 import FavoriteCompany from "@/components/FavoriteCompany";
-import { JOB_TYPES } from "@/constants/filtersJob";
 import useJobFilter from "@/hooks/useJobFilter";
 import {
   selectCareerLevel,
@@ -36,27 +35,26 @@ const JobItem = ({
     addState: UnknownAction,
     removeState?: UnknownAction
   ): void => {
-    if (!filtersItem.includes(text)) {
-      dispatch(addState);
-      dispatch(selectFiltersItem([...filtersItem, text]));
+    const isIncludesText = filtersItem.includes(text);
+    const updatedFilters = isIncludesText
+      ? filtersItem.filter((item) => item !== text)
+      : [...filtersItem, text];
+
+    dispatch(selectFiltersItem(updatedFilters));
+    if (isIncludesText && removeState) {
+      dispatch(removeState);
     } else {
-      filterJob();
-      if (removeState) dispatch(removeState);
-      dispatch(selectFiltersItem(filtersItem.filter((item) => item !== text)));
+      dispatch(addState);
+    }
+
+    filterJob();
+    if (window.innerWidth <= 640) {
+      window.scrollTo({ top: 596.98 });
+    } else {
+      window.scrollTo({ top: 425.23 });
     }
   };
 
-  const handleJobTypeBadge = () => {
-    const isIncludes = filtersItem.includes(job.modeOfWork);
-    const filtredJobs = filtersItem.filter((fi) => !JOB_TYPES.includes(fi));
-
-    const updatedFilters = isIncludes
-      ? filtredJobs
-      : [...filtredJobs, job.modeOfWork];
-
-    dispatch(selectFiltersItem(updatedFilters));
-    dispatch(selectJobType(isIncludes ? "" : job.modeOfWork));
-  };
   return (
     <article
       key={job.postId}
@@ -141,7 +139,13 @@ const JobItem = ({
           <div className="mt-3 flex max-[430px]:flex-col gap-x-[15px] gap-y-2 max-[450px]:justify-center">
             <span
               className="featured-job-list-item max-[450px]:flex-[1] whitespace-nowrap bg-[#1967d2] border-none !text-white cursor-pointer"
-              onClick={handleJobTypeBadge}
+              onClick={() =>
+                handleAction(
+                  job.modeOfWork,
+                  selectJobType(job.modeOfWork),
+                  selectJobType("")
+                )
+              }
             >
               {job.modeOfWork}
             </span>

--- a/components/pages/jobPostings/jobs/ResultNavigator.tsx
+++ b/components/pages/jobPostings/jobs/ResultNavigator.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/redux/features/filterJobs/filters";
 import { RootState } from "@/lib/redux/store";
 import { useSelector } from "react-redux";
+import { setOpenCustomList } from "@/lib/redux/features/touch";
 
 const ResultNavigator = ({
   searchedDataLength,
@@ -20,7 +21,7 @@ const ResultNavigator = ({
     filtersItem,
     filterData: { countJobs, isFilter },
   } = useSelector((state: RootState) => state.jobFilters);
-  const { touch, touchSortList } = useSelector(
+  const { touch, touchSortList, openCustomList } = useSelector(
     (state: RootState) => state.touch
   );
 
@@ -44,7 +45,7 @@ const ResultNavigator = ({
         </p>
       </div>
 
-      <div className="flex flex-wrap gap-x-5 gap-y-3  max-md:w-full">
+      <div className="flex max-sm:flex-col gap-x-5 gap-y-3  max-md:w-full">
         <div className={`${touch ? "-z-[1]" : "z-[1]"} max-md:flex-[1]`}>
           <CustomList
             options={["Sıralama (Varsayılan)", "En yeni", "En eski"]}
@@ -53,6 +54,8 @@ const ResultNavigator = ({
             defaultValue="Sıralama (Varsayılan)"
             screenClass="!bg-[#f0f5f7] !w-[222.45px] max-md:!w-full"
             listClass="!w-[222.45px] max-md:!w-full"
+            openCustomList={openCustomList}
+            setOpenCustomList={setOpenCustomList}
           />
         </div>
 
@@ -68,6 +71,8 @@ const ResultNavigator = ({
             defaultValue="Sayfa Başına 10"
             screenClass="!bg-[#f0f5f7] !w-[190.44px] max-md:!w-full"
             listClass="!w-[190.44px] max-md:!w-full"
+            openCustomList={openCustomList}
+            setOpenCustomList={setOpenCustomList}
           />
         </div>
       </div>

--- a/lib/redux/features/touch.ts
+++ b/lib/redux/features/touch.ts
@@ -1,20 +1,33 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
+const initialState: initialState = {
+  touch: false,
+  touchSortList: false,
+  openCustomList: "",
+};
+
+interface initialState {
+  touch: boolean;
+  touchSortList: boolean;
+  openCustomList: string;
+}
+
 export const touch = createSlice({
   name: "touch",
-  initialState: { touch: false, touchSortList: false },
+  initialState,
   reducers: {
-    setTouch: (state: { touch: boolean }, action: PayloadAction<boolean>) => {
+    setTouch: (state: initialState, action: PayloadAction<boolean>) => {
       state.touch = action.payload;
     },
 
-    setTouchSortList: (
-      state: { touchSortList: boolean },
-      action: PayloadAction<boolean>
-    ) => {
+    setTouchSortList: (state: initialState, action: PayloadAction<boolean>) => {
       state.touchSortList = action.payload;
+    },
+
+    setOpenCustomList: (state: initialState, action: PayloadAction<string>) => {
+      state.openCustomList = action.payload;
     },
   },
 });
 
-export const { setTouch, setTouchSortList } = touch.actions;
+export const { setTouch, setTouchSortList, setOpenCustomList } = touch.actions;

--- a/types/filtersJob.ts
+++ b/types/filtersJob.ts
@@ -1,4 +1,4 @@
-import { UnknownAction } from "@reduxjs/toolkit";
+import { ActionCreatorWithPayload, UnknownAction } from "@reduxjs/toolkit";
 
 export type JobTypes = string[];
 
@@ -27,6 +27,11 @@ export interface CustomListProps {
   screenClass?: string;
   listClass?: string;
   listWrapperClass?: string;
+  openCustomList: string;
+  setOpenCustomList: ActionCreatorWithPayload<
+    string,
+    "touch/setOpenCustomList"
+  >;
 }
 
 export interface JobSearchFilters {


### PR DESCRIPTION
This pull request addresses a UI/UX bug in the custom filter list and improves user experience by enforcing a consistent and predictable interaction model across components.

---

## ✨ What’s Changed

### 🎯 Behavior & UX Improvements
- Ensured only one custom list remains open at a time to avoid UI conflicts
- Improved user interaction in filter dropdowns by centralizing open state logic

### 🛠️ Component-Level Changes
- Refactored `CustomList` to support external control via `openCustomList` and `setOpenCustomList`
- Integrated the new props into `FilterMenu`, `FilterMenuMobile`, and `ResultNavigator`

### 📦 Code Cleanup & Enhancements
- Removed redundant `handleJobTypeBadge` from `JobItem`
- Enhanced `handleAction` with scroll-to functionality for smoother navigation

### 🧠 State Management
- Added `openCustomList` field to `touch` slice in Redux store  
- Created a new `setOpenCustomList` reducer for controlling open state globally

### 🧾 Type Safety
- Extended `CustomListProps` interface with the new props for stricter typing

---

## 📌 Summary

> This fix introduces a more intuitive and clean filter interaction, minimizes user confusion, and lays the groundwork for better scalability in filter UI logic.
