### PR TITLE
feat(resume): implement resume fetching, listing, and PDF download functionality

### DIFF
--- a/app/api/resume/fetch-resume/[slug]/route.ts
+++ b/app/api/resume/fetch-resume/[slug]/route.ts
@@ -35,7 +35,11 @@ export async function GET(req: NextRequest): Promise<
     const docSnap = await getDoc(docRef);
     resumeData.push(...(docSnap.data()?.uploadedResumes ?? []));
 
-    return NextResponse.json({ resumeData: resumeData }, { status: 200 });
+    const sortedData = resumeData.toSorted(
+      (a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt)
+    );
+
+    return NextResponse.json({ resumeData: sortedData }, { status: 200 });
   } catch (error) {
     if (error instanceof Error)
       return NextResponse.json({ message: error.message }, { status: 400 });

--- a/app/api/resume/upload-resume/route.ts
+++ b/app/api/resume/upload-resume/route.ts
@@ -36,9 +36,11 @@ export async function POST(req: NextRequest) {
         await updateDoc(docRef, {
           uploadedResumes: arrayUnion({
             uploadTime: dayjs().format("DD.MM.YYYY"),
-            resume: data.secure_url,
+            url: data.secure_url,
             cvID: cvID,
             size: calculateCVSize(file.size),
+            fileName: file.name,
+            createdAt: data.created_at,
           }),
         });
       };

--- a/app/is-ilani/page.tsx
+++ b/app/is-ilani/page.tsx
@@ -5,11 +5,10 @@ import { Timestamp } from "firebase/firestore";
 import { Toaster } from "react-hot-toast";
 import { useGetJobDetailQuery } from "@/lib/redux/services/jobDetail";
 import { useSearchParams } from "next/navigation";
-import React, { useEffect } from "react";
+import React from "react";
 import ApplicationModal from "@/components/pages/jobDetail/applicationModal/ApplicationModal";
-import { useDispatch, useSelector } from "react-redux";
-import { AppDispatch, RootState } from "@/lib/redux/store";
-import { setApplicationModal } from "@/lib/redux/features/touch";
+import { useSelector } from "react-redux";
+import { RootState } from "@/lib/redux/store";
 import { JobPostingAdditionalQuestions } from "@/types";
 
 const JobDetail = () => {
@@ -21,14 +20,6 @@ const JobDetail = () => {
   const { openApplicationModal } = useSelector(
     (state: RootState) => state.touch
   );
-  const dispatch = useDispatch<AppDispatch>();
-
-  useEffect(() => {
-    window.addEventListener("click", () => {
-      dispatch(setApplicationModal(false));
-      document.body.style.overflow = "visible";
-    });
-  }, [dispatch]);
 
   return (
     <main>

--- a/components/pages/jobDetail/applicationModal/ApplicationModal.tsx
+++ b/components/pages/jobDetail/applicationModal/ApplicationModal.tsx
@@ -9,6 +9,7 @@ import {
   setIsAdditionalQuestions,
   setProgressBarValue,
 } from "@/lib/redux/features/applicationModal/progressBar";
+import { setApplicationModal } from "@/lib/redux/features/touch";
 
 const ApplicationModal = ({
   companyName,
@@ -21,6 +22,11 @@ const ApplicationModal = ({
 }) => {
   const dispatch = useDispatch<AppDispatch>();
 
+  const handleCloseModal = () => {
+    dispatch(setApplicationModal(false));
+    document.body.style.overflow = "visible";
+  };
+
   useEffect(() => {
     dispatch(
       setProgressBarValue({
@@ -32,9 +38,12 @@ const ApplicationModal = ({
   }, [additionalQuestions, dispatch]);
 
   return (
-    <div className="fixed top-0 left-0 w-full h-full z-50 bg-black/25">
+    <div
+      className="fixed top-0 left-0 w-full h-full z-50 bg-black/25"
+      onClick={handleCloseModal}
+    >
       <div
-        className="bg-white fixed left-1/2 top-[32px] -translate-x-1/2 rounded-lg w-[744px] max-md:w-[95%]"
+        className="bg-white fixed left-1/2 top-[32px] -translate-x-1/2 rounded-lg w-[744px] max-md:w-[95%]  max-sm:h-[500px] max-sm:overflow-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <ModalHeader companyName={companyName} jobTitle={jobTitle} />

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/ResumeItem.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/ResumeItem.tsx
@@ -1,7 +1,37 @@
 import React from "react";
+import { CVDataFields } from "@/types/resume";
+import ResumeContent from "./resumeItem/ResumeContent";
+import DownloadButton from "./resumeItem/DownloadButton";
+import RadioButton from "./resumeItem/RadioButton";
 
-const ResumeItem = () => {
-  return <div>ResumeItem</div>;
+const ResumeItem = ({
+  resume: { fileName, size, uploadTime, url },
+}: {
+  resume: CVDataFields;
+}) => {
+  return (
+    <li className="flex border border-[#E8E8E8] rounded-[12.8px] cursor-pointer mb-3">
+      <div className="bg-[#cb112d] grid place-content-center w-[44px] h-auto rounded-s-[12.8px]">
+        <span className="text-white text-sm font-medium">PDF</span>
+      </div>
+
+      <div className="py-3 px-2 flex items-center justify-between w-[calc(100%-44px)] hover:bg-[#f8fafd] rounded-e-[12.8px] transition-colors">
+        <ResumeContent
+          fileName={fileName}
+          size={size}
+          uploadTime={uploadTime}
+        />
+
+        <div className="flex items-center gap-3 pe-1.5">
+          <DownloadButton fileName={fileName} url={url} />
+
+          <span className="w-[0.5px] bg-[#E8E8E8] h-[40px] inline-block mx-1"></span>
+
+          <RadioButton />
+        </div>
+      </div>
+    </li>
+  );
 };
 
 export default ResumeItem;

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/ResumeList.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/ResumeList.tsx
@@ -1,7 +1,70 @@
-import React from "react";
+import { AuthContext } from "@/context/authContext";
+import { useFetchResumeQuery } from "@/lib/redux/services/resumeApi";
+import { AppDispatch, RootState } from "@/lib/redux/store";
+import React, { useContext, useEffect, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import ResumeItem from "./ResumeItem";
+import {
+  setPlaceholderUploadData,
+  setUploadedFileNames,
+} from "@/lib/redux/features/applicationModal/modalData";
+import ShowMoreResumes from "./ShowMoreResumes";
 
 const ResumeList = () => {
-  return <div className="px-6">ResumeList</div>;
+  const { user } = useContext(AuthContext);
+  const { cvID } = useSelector((state: RootState) => state.cvIdSlice);
+  const { placeholderUploadData } = useSelector(
+    (state: RootState) => state.applicationModalData
+  );
+  const { showMoreResumes } = useSelector((state: RootState) => state.touch);
+  const dispatch = useDispatch<AppDispatch>();
+  const { data } = useFetchResumeQuery({
+    docID: user?.id ?? "",
+    cvID: cvID,
+  });
+  const resumeData = useMemo(() => data?.resumeData ?? [], [data?.resumeData]);
+  const findMatchUpload = resumeData.find(
+    (resume) => resume.fileName == placeholderUploadData.fileName
+  );
+
+  useEffect(() => {
+    if (findMatchUpload) {
+      dispatch(
+        setPlaceholderUploadData({ fileName: "", size: 0, uploadTime: "" })
+      );
+    }
+  }, [dispatch, findMatchUpload]);
+
+  useEffect(() => {
+    const fileName = resumeData.map((resume) => resume.fileName);
+
+    dispatch(setUploadedFileNames(fileName));
+  }, [resumeData, dispatch]);
+
+  return (
+    <div className="px-6 mb-4 mt-2">
+      <ul>
+        {/* ↓ this section will then use the placeholder resume element. (currently temporary) ↓ */}
+        {!findMatchUpload && placeholderUploadData.fileName.length
+          ? "Özgeçmiş yükleniyor.."
+          : ""}
+        {/* ↑ this section will then use the placeholder resume element. (currently temporary) ↑ */}
+
+        {resumeData.slice(0, 2).map((resume) => (
+          <ResumeItem key={resume.cvID} resume={resume} />
+        ))}
+
+        {showMoreResumes &&
+          resumeData
+            .slice(2, resumeData.length)
+            .map((resume) => <ResumeItem key={resume.cvID} resume={resume} />)}
+      </ul>
+
+      {resumeData.length > 2 && (
+        <ShowMoreResumes resumeDataLength={resumeData.length} />
+      )}
+    </div>
+  );
 };
 
 export default ResumeList;

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/ShowMoreResumes.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/ShowMoreResumes.tsx
@@ -1,0 +1,38 @@
+import { changeShowMoreResumes } from "@/lib/redux/features/touch";
+import { AppDispatch, RootState } from "@/lib/redux/store";
+import React from "react";
+import { RiArrowDownWideLine } from "react-icons/ri";
+import { RiArrowUpWideLine } from "react-icons/ri";
+import { useDispatch, useSelector } from "react-redux";
+
+const ShowMoreResumes = ({
+  resumeDataLength,
+}: {
+  resumeDataLength: number;
+}) => {
+  const dispatch = useDispatch<AppDispatch>();
+  const { showMoreResumes } = useSelector((state: RootState) => state.touch);
+
+  return (
+    <div className="float-end max-[460px]:float-none pt-1">
+      <button
+        className="text-[#4045ef] font-medium flex items-center gap-x-1 hover:bg-[#EBF4FD] py-1.5 px-2 rounded-[6.4px] transition-colors duration-300"
+        onClick={() => dispatch(changeShowMoreResumes())}
+      >
+        <span>
+          {showMoreResumes
+            ? "Daha az göster"
+            : `${resumeDataLength - 2} Özgeçmiş daha göster`}
+        </span>
+
+        {showMoreResumes ? (
+          <RiArrowUpWideLine size={20} strokeWidth={0.5} />
+        ) : (
+          <RiArrowDownWideLine size={20} strokeWidth={0.5} />
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default ShowMoreResumes;

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/UploadResume.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/UploadResume.tsx
@@ -1,25 +1,30 @@
-import React, { ChangeEvent, useContext, useState } from "react";
+import React, { ChangeEvent, useContext, useRef, useState } from "react";
 import InformationMessage from "../../modalUI/InformationMessage";
 import { useDispatch, useSelector } from "react-redux";
 import { AppDispatch, RootState, store } from "@/lib/redux/store";
 import { Form, Formik } from "formik";
 import ModalControls from "../../modalControls/ModalControls";
-import { setApplicationData } from "@/lib/redux/features/applicationModal/modalData";
+import {
+  setApplicationData,
+  setPlaceholderUploadData,
+} from "@/lib/redux/features/applicationModal/modalData";
 import { ResumeSchema } from "@/app/(auth)/schema/ApplicationModal/ResumeSchema";
 import validatePdfFile from "@/lib/utils/validatePdfFile";
 import { useUploadResumeMutation } from "@/lib/redux/services/resumeApi";
 import { AuthContext } from "@/context/authContext";
 import { nanoid } from "@reduxjs/toolkit";
 import { setCvID } from "@/lib/redux/features/applicationModal/cvIdSlice";
+import dayjs from "dayjs";
 
 const UploadResume = () => {
-  const { applicationData } = useSelector(
+  const { applicationData, uploadedFileNames } = useSelector(
     (state: RootState) => state.applicationModalData
   );
   const dispatch = useDispatch<AppDispatch>();
   const [pdfMessage, setPdfMessage] = useState<string>("");
   const [uploadResume] = useUploadResumeMutation();
   const { user } = useContext(AuthContext);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleUploadResume = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -34,7 +39,19 @@ const UploadResume = () => {
         setPdfMessage(
           "PDF dosyası geçersiz ya da bozuk lütfen başka bir dosya yükleyin"
         );
+      } else if (uploadedFileNames.includes(file.name)) {
+        setPdfMessage("Bu dosyayı zaten yüklediniz");
+      } else if (uploadedFileNames.length > 3) {
+        setPdfMessage("En fazla 4 tane yükleyebilirsiniz");
       } else {
+        dispatch(
+          setPlaceholderUploadData({
+            fileName: file.name,
+            size: file.size,
+            uploadTime: dayjs().format("DD.MM.YYYY"),
+          })
+        );
+
         setPdfMessage("");
         dispatch(setCvID(nanoid()));
         const { cvID } = store.getState().cvIdSlice;
@@ -50,6 +67,10 @@ const UploadResume = () => {
             resume: data?.resumeData?.secure_url,
           })
         );
+      }
+
+      if (fileInputRef.current) {
+        e.target.value = "";
       }
     }
   };
@@ -87,6 +108,7 @@ const UploadResume = () => {
                   setFieldValue("resume", e.target.files?.[0]);
                   handleUploadResume(e);
                 }}
+                ref={fileInputRef}
               />
               <div className="text-[#D91B1B] text-[15px] mt-1">
                 {errors.resume ? errors.resume : pdfMessage}

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/DownloadButton.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/DownloadButton.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import fileDownload from "js-file-download";
+import { HiMiniArrowDownTray } from "react-icons/hi2";
+import { fetchData } from "@/lib/fetchData";
+
+const DownloadButton = ({
+  url,
+  fileName,
+}: {
+  url: string;
+  fileName: string;
+}) => {
+  const handleDownloadPdf = async (url: string, fileName: string) => {
+    const { data } = await fetchData<string>(url, { responseType: "blob" });
+    fileDownload(data, fileName);
+  };
+
+  return (
+    <button
+      onClick={() => handleDownloadPdf(url, fileName)}
+      rel="noopener noreferrer"
+    >
+      <HiMiniArrowDownTray
+        size={40}
+        color="#000000BF"
+        cursor="pointer"
+        className="hover:bg-[#8c8c8c1a] rounded-full p-2 transition-colors duration-300"
+      />
+    </button>
+  );
+};
+
+export default DownloadButton;

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/RadioButton.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/RadioButton.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const RadioButton = () => {
+  return (
+    <button className="w-[24px] h-[24px] border-2 border-[#000000BF] hover:shadow-[inset_0px_0px_0px_1px_#000000BF] hover:bg-[#8c8c8c1a] transition duration-300 rounded-full cursor-pointer" />
+  );
+};
+
+export default RadioButton;

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/ResumeContent.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/ResumeContent.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+const ResumeContent = ({
+  fileName,
+  size,
+  uploadTime,
+}: {
+  fileName: string;
+  size: string;
+  uploadTime: string;
+}) => {
+  return (
+    <div className="overflow-hidden">
+      <h3 className="text-[#000000E6] text-xs font-semibold whitespace-nowrap text-ellipsis overflow-hidden">
+        {fileName}
+      </h3>
+      <p className="text-[#00000099] text-xs pt-1 whitespace-nowrap text-ellipsis">
+        {size} · {uploadTime} tarihinde yüklendi
+      </p>
+    </div>
+  );
+};
+
+export default ResumeContent;

--- a/components/pages/jobDetail/applicationModal/modalUI/InformationMessage.tsx
+++ b/components/pages/jobDetail/applicationModal/modalUI/InformationMessage.tsx
@@ -7,7 +7,7 @@ const InformationMessage = () => {
       <p className="text-[#00000099] text-xs">
         Bu başvurunun gönderilmesi,{" "}
         <strong className="font-semibold">NextHire</strong> profilinizde
-        herhangi bir değişiklik yapmaz. <br /> Başvurular,{" "}
+        herhangi bir değişiklik yapmaz. <br className="max-[500px]:hidden" /> Başvurular,{" "}
         <strong className="font-semibold">NextHire</strong> altyapısı ile
         desteklenmektedir. Daha fazla bilgi için{" "}
         <Link href="#" className="text-[#4045ef] hover:underline">

--- a/components/pages/jobDetail/applicationModal/modalUI/ModalHeader.tsx
+++ b/components/pages/jobDetail/applicationModal/modalUI/ModalHeader.tsx
@@ -21,8 +21,8 @@ const ModalHeader = ({
   };
 
   return (
-    <div className="flex justify-between items-center max-md:items-start py-4 px-6 border-b border-gray-200">
-      <h2 className="text-xl font-medium max-[430px]:text-lg">
+    <div className="flex justify-between items-center max-md:items-start max-md:gap-x-3 py-4 px-6 border-b border-gray-200">
+      <h2 className="text-xl font-medium max-[430px]:text-lg max-md:self-end whitespace-nowrap text-ellipsis overflow-hidden">
         <strong className="font-medium">{companyName}</strong> şirketinin{" "}
         <strong className="font-medium">{jobTitle}</strong> ilanına
         başvuruyorsunuz{" "}

--- a/lib/fetchData.ts
+++ b/lib/fetchData.ts
@@ -1,6 +1,9 @@
-import axios from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 
-export const fetchData = async <T>(url: string): Promise<{ data: T }> => {
-  const response = await axios.get<T>(url);
+export const fetchData = async <T>(
+  url: string,
+  config: AxiosRequestConfig
+): Promise<{ data: T }> => {
+  const response = await axios.get<T>(url, config);
   return { data: response.data };
 };

--- a/lib/fetchData.ts
+++ b/lib/fetchData.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestConfig } from "axios";
 
 export const fetchData = async <T>(
   url: string,
-  config: AxiosRequestConfig
+  config?: AxiosRequestConfig
 ): Promise<{ data: T }> => {
   const response = await axios.get<T>(url, config);
   return { data: response.data };

--- a/lib/redux/features/applicationModal/modalData.ts
+++ b/lib/redux/features/applicationModal/modalData.ts
@@ -1,3 +1,4 @@
+import { CVDataFields } from "@/types/resume";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 interface modalDataState {
@@ -7,13 +8,31 @@ interface modalDataState {
   additionalQuestions: object[];
 }
 
-const initialState = {
+interface initialStateFields {
+  applicationData: modalDataState;
+  placeholderUploadData: {
+    fileName: string;
+    size: number;
+    uploadTime: string;
+  };
+  uploadedFileNames: string[];
+}
+
+const initialState: initialStateFields = {
   applicationData: {
     email: "",
     phone: "",
     resume: "",
     additionalQuestions: [],
   },
+
+  placeholderUploadData: {
+    fileName: "",
+    size: 0,
+    uploadTime: "",
+  },
+
+  uploadedFileNames: [],
 };
 
 export const applicationModalDataSlice = createSlice({
@@ -39,7 +58,24 @@ export const applicationModalDataSlice = createSlice({
         }
       });
     },
+
+    setPlaceholderUploadData: (
+      state,
+      action: PayloadAction<
+        Pick<CVDataFields, "fileName" | "uploadTime"> & { size: number }
+      >
+    ) => {
+      state.placeholderUploadData = action.payload;
+    },
+
+    setUploadedFileNames: (state, action: PayloadAction<string[]>) => {
+      state.uploadedFileNames = action.payload;
+    },
   },
 });
 
-export const { setApplicationData } = applicationModalDataSlice.actions;
+export const {
+  setApplicationData,
+  setPlaceholderUploadData,
+  setUploadedFileNames,
+} = applicationModalDataSlice.actions;

--- a/lib/redux/features/touch.ts
+++ b/lib/redux/features/touch.ts
@@ -5,6 +5,7 @@ const initialState: initialState = {
   touchSortList: false,
   openCustomList: "",
   openApplicationModal: false,
+  showMoreResumes: false,
 };
 
 interface initialState {
@@ -12,6 +13,7 @@ interface initialState {
   touchSortList: boolean;
   openCustomList: string;
   openApplicationModal: boolean;
+  showMoreResumes: boolean;
 }
 
 export const touch = createSlice({
@@ -36,6 +38,10 @@ export const touch = createSlice({
     ) => {
       state.openApplicationModal = action.payload;
     },
+
+    changeShowMoreResumes: (state) => {
+      state.showMoreResumes = !state.showMoreResumes;
+    },
   },
 });
 
@@ -44,4 +50,5 @@ export const {
   setTouchSortList,
   setOpenCustomList,
   setApplicationModal,
+  changeShowMoreResumes,
 } = touch.actions;

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
-        "@netlify/plugin-nextjs": "^5.11.4",
+        "@netlify/plugin-nextjs": "^5.11.5",
         "@tailwindcss/postcss": "^4",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -3355,9 +3355,9 @@
       }
     },
     "node_modules/@netlify/plugin-nextjs": {
-      "version": "5.11.4",
-      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.11.4.tgz",
-      "integrity": "sha512-hJJthlDU76wn1vuOF48GiYx7HLhSK0u9xJU7N4BSmOjc741zvI5NgfWlQwfPOydp5OOuoxPDXxbZj9EttBycPw==",
+      "version": "5.11.5",
+      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.11.5.tgz",
+      "integrity": "sha512-dI3sKldRENHpg0hygYo6zqpniG/rR+fyG62AGQYHH707FMDCArqF1H7ZSMmN50YsNXv9VctA4rH7ygrUL8lBkA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "firebase": "^11.6.0",
         "formik": "^2.4.6",
         "framer-motion": "^12.11.0",
+        "js-file-download": "^0.4.12",
         "next": "15.2.4",
         "next-sitemap": "^4.2.3",
         "pdfjs-dist": "^5.3.93",
@@ -9694,6 +9695,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-file-download": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
+      "integrity": "sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
-    "@netlify/plugin-nextjs": "^5.11.4",
+    "@netlify/plugin-nextjs": "^5.11.5",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "firebase": "^11.6.0",
     "formik": "^2.4.6",
     "framer-motion": "^12.11.0",
+    "js-file-download": "^0.4.12",
     "next": "15.2.4",
     "next-sitemap": "^4.2.3",
     "pdfjs-dist": "^5.3.93",

--- a/types/resume.ts
+++ b/types/resume.ts
@@ -24,8 +24,10 @@ export interface UploadedCV {
 }
 
 export interface CVDataFields {
-  resume: string;
+  url: string;
   cvID: string;
   uploadTime: string;
-  size: string
+  size: string;
+  fileName: string;
+  createdAt: string;
 }


### PR DESCRIPTION
## Summary

This PR introduces resume listing functionality using data from Firestore and enables users to download resumes in PDF format. It also includes several component and Redux state enhancements to support improved UX and scalability.

---

## Changes

### ♻️ Components
- `ResumeList`: Lists resumes using Firestore data
- `ResumeItem`: Defines the structure of individual resume entries
- `DownloadButton`: Handles PDF download logic using `js-file-download`
- `RadioButton`, `DownloadButton`, `ResumeContent`: Created and integrated into `ResumeItem`
- `ShowMoreResumes`: Limits initial display to 2 resumes; shows a "Show more" button if more exist, allowing users to expand the list

### ⚙️ State & Data
- Added `showMoreResumes` state to `touch` slice
- Added `placeholderUploadData` state to `modalData` slice
- Integrated `setPlaceholderUploadData` dispatch in `Resume` component
- Improved error handling across resume-related flows

### 📦 API & Types
- Updated `/api/resume/fetch-resume` to return resumes sorted by date
- Updated `/api/resume/upload-resume` to match the updated `CVDataFields` interface
- Updated the `CVDataFields` interface in `types/resume`

### 🔧 Others
- Removed unnecessary `useEffect` from `is-ilani` route
- Enhanced `ApplicationModal`:
  - Added click-outside-to-close behavior
  - Improved responsive layout
- Refactored `fetchData` function for better reusability