### PR TITLE
refactor(types): reorganize employer role and signup field names

### DIFF
--- a/app/(auth)/components/employer/EmployerForm.tsx
+++ b/app/(auth)/components/employer/EmployerForm.tsx
@@ -11,7 +11,6 @@ import { EmployerSignupSchema } from "../../schema/EmployerSignupSchema";
 import {
   CitiesJsonInterface,
   DistrictsJsonInterface,
-  EmployerSignupFormFields,
   TaxOfficiesJsonInterface,
 } from "@/types";
 import { fetchData } from "@/lib/fetchData";
@@ -31,6 +30,7 @@ import { signInWithEmailAndPassword } from "firebase/auth";
 import { auth } from "@/app/api/firebase/firebaseConfig";
 import { useRouter } from "next/navigation";
 import { Inter } from "next/font/google";
+import { EmployerSignupFormFields } from "@/types/auth/employer/signup-form.types";
 
 const inter = Inter({
   subsets: ["latin-ext"],
@@ -58,28 +58,25 @@ const EmployerForm = () => {
       password,
       phone,
       companyName,
-      selectCity,
-      selectDistricts,
-      selectTaxOfficiesCity,
-      selectTaxOffice,
+      city,
+      district,
+      taxCity,
+      taxOffice,
       taxNumber,
     } = values;
 
     if (pathname === "/isveren-kayit") {
-      const response = await axios.post(
-        "/api/firebase/employer-signup",
-        JSON.stringify({
-          nameAndSurname: nameAndSurname,
-          email: email,
-          phoneNumber: phone,
-          companyName: companyName,
-          city: selectCity,
-          district: selectDistricts,
-          TaxOfficieCity: selectTaxOfficiesCity,
-          TaxOffice: selectTaxOffice,
-          taxNumber: taxNumber,
-        })
-      );
+      const response = await axios.post("/api/firebase/employer-signup", {
+        nameAndSurname: nameAndSurname,
+        email: email,
+        phoneNumber: phone,
+        companyName: companyName,
+        city: city,
+        district: district,
+        taxCity: taxCity,
+        taxOffice: taxOffice,
+        taxNumber: taxNumber,
+      });
 
       const data = await response.data;
 
@@ -198,10 +195,10 @@ const EmployerForm = () => {
               taxNumber: "",
               checkboxFirst: false,
               checkboxSecond: false,
-              selectCity: "",
-              selectDistricts: "",
-              selectTaxOfficiesCity: "",
-              selectTaxOffice: "",
+              city: "",
+              district: "",
+              taxCity: "",
+              taxOffice: "",
             }}
             onSubmit={onSubmit}
             validationSchema={
@@ -302,7 +299,7 @@ const EmployerForm = () => {
 
                     <div className="flex gap-4">
                       <AuthSelect
-                        value={values.selectCity}
+                        value={values.city}
                         handleChange={handleChange}
                         handleChangeCapture={(e) =>
                           setSelectedData(
@@ -313,23 +310,23 @@ const EmployerForm = () => {
                         }
                         data={cities}
                         defaultValue="İl Seçiniz"
-                        name="selectCity"
+                        name="city"
                         isSubmitting={isSubmitting}
                       />
 
                       <AuthSelect
-                        value={values.selectDistricts}
+                        value={values.district}
                         handleChange={handleChange}
                         data={districts}
                         defaultValue="İlçe Seçiniz"
-                        name="selectDistricts"
+                        name="district"
                         isSubmitting={isSubmitting}
                       />
                     </div>
 
                     <div className="flex gap-4 my-4">
                       <AuthSelect
-                        value={values.selectTaxOfficiesCity}
+                        value={values.taxCity}
                         handleChange={handleChange}
                         handleChangeCapture={(e) =>
                           setSelectedData(
@@ -340,16 +337,16 @@ const EmployerForm = () => {
                         }
                         data={cities}
                         defaultValue="Vergi Dairesi İli Seçiniz"
-                        name="selectTaxOfficiesCity"
+                        name="taxCity"
                         isSubmitting={isSubmitting}
                       />
 
                       <AuthSelect
-                        value={values.selectTaxOffice}
+                        value={values.taxOffice}
                         handleChange={handleChange}
                         data={taxOfficies}
                         defaultValue="Vergi Dairesi Seçiniz"
-                        name="selectTaxOffice"
+                        name="taxOffice"
                         isSubmitting={isSubmitting}
                       />
                     </div>

--- a/app/(auth)/schema/EmployerSignupSchema.ts
+++ b/app/(auth)/schema/EmployerSignupSchema.ts
@@ -29,19 +29,19 @@ export const EmployerSignupSchema = Yup.object().shape({
     .min(2, "Şirket adı en az 2 karakter olmalı.")
     .required("Şirket adı gereklidir."),
 
-  selectCity: Yup.string()
+  city: Yup.string()
     .notOneOf(["İl Seçiniz"], "Bir şehir seçmelisiniz.")
     .required("Şehir seçimi gereklidir."),
 
-  selectDistricts: Yup.string()
+  district: Yup.string()
     .notOneOf(["İlçe Seçiniz"], "Bir ilçe seçmelisiniz.")
     .required("İlçe seçimi gereklidir."),
 
-  selectTaxOfficiesCity: Yup.string()
+  taxCity: Yup.string()
     .notOneOf(["Vergi Dairesi İli Seçiniz"], "Vergi dairesi ili seçmelisiniz.")
     .required("Vergi dairesi ili gereklidir."),
 
-  selectTaxOffice: Yup.string()
+  taxOffice: Yup.string()
     .notOneOf(["Vergi Dairesi Seçiniz"], "Vergi dairesi seçmelisiniz.")
     .required("Vergi dairesi gereklidir."),
 

--- a/app/api/firebase/candidate-signup/route.ts
+++ b/app/api/firebase/candidate-signup/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: NextRequest) {
     }
 
     const createdData = {
-      cid: userCredential.user.uid,
+      id: userCredential.user.uid,
       name: `${name} ${surname}`,
       acceptedTerms: acceptedTerms,
       email: email,

--- a/app/api/firebase/employer-signup/route.ts
+++ b/app/api/firebase/employer-signup/route.ts
@@ -16,8 +16,8 @@ export async function POST(req: NextRequest) {
     companyName,
     city,
     district,
-    TaxOfficieCity,
-    TaxOffice,
+    taxCity,
+    taxOffice,
     taxNumber,
   } = await req.json();
 
@@ -32,19 +32,19 @@ export async function POST(req: NextRequest) {
 
     const createdData = {
       companyInformations: {
-        name: nameAndSurname,
         companyName: companyName,
         phoneNumber: formatTurkishPhoneNumber(phoneNumber),
         email: email,
         location: {
           city: city,
           district: FormatText(district),
-          taxOfficieCity: TaxOfficieCity,
-          taxOffice: FormatText(TaxOffice),
+          taxCity: taxCity,
+          taxOffice: FormatText(taxOffice),
           taxNumber: taxNumber,
         },
       },
-      eid: userCredential.user.uid,
+      name: nameAndSurname,
+      id: userCredential.user.uid,
       emailVerified: userCredential.user.emailVerified,
       role: "employer",
     };

--- a/app/api/firebase/employers/[slug]/route.ts
+++ b/app/api/firebase/employers/[slug]/route.ts
@@ -1,7 +1,7 @@
 import { collection, query, where, getDocs } from "firebase/firestore";
 import { NextResponse } from "next/server";
 import { db } from "../../firebaseConfig";
-import { Employer } from "@/types";
+import { Employer } from "@/types/auth/models/employer";
 
 export async function GET(
   _request: Request,

--- a/app/api/firebase/favorites/route.ts
+++ b/app/api/firebase/favorites/route.ts
@@ -15,14 +15,13 @@ export async function POST(req: NextRequest) {
 
   try {
     if (user?.role === "candidate") {
-      const userId = user?.id ?? user?.cid;
       const isAlreadyFavorited = updatedData?.[fieldName]?.some(
         (item) => item.postID === id
       );
       const action = isAlreadyFavorited ? "remove" : "add";
 
       const updateFavorite = async (path: string) => {
-        const ref = doc(db, path, userId);
+        const ref = doc(db, path, user?.id);
         const updateData =
           action === "add"
             ? { [fieldName]: arrayUnion(data) }

--- a/app/api/firebase/job-detail/route.ts
+++ b/app/api/firebase/job-detail/route.ts
@@ -1,7 +1,7 @@
 import { collection, getDocs, limit, query, where } from "firebase/firestore";
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "../firebaseConfig";
-import { EmployerOpenJobs } from "@/types";
+import { EmployerOpenJobs } from "@/types/auth/employer/open-jobs.types";
 
 /**
  * API route handler to fetch job posting details.
@@ -21,7 +21,7 @@ export async function POST(req: NextRequest) {
   try {
     const docRef = query(
       collection(db, "employers"),
-      where("eid", "==", companyID),
+      where("id", "==", companyID),
       limit(1)
     );
     const docData = await getDocs(docRef);

--- a/app/api/firebase/job-postings/route.ts
+++ b/app/api/firebase/job-postings/route.ts
@@ -1,8 +1,8 @@
 import { collection, getDocs, orderBy, query, where } from "firebase/firestore";
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "../firebaseConfig";
-import { EmployerOpenJobs } from "@/types";
 import { normalize } from "@/lib/routeFormat";
+import { EmployerOpenJobs } from "@/types/auth/employer/open-jobs.types";
 
 export async function POST(req: NextRequest) {
   const {
@@ -59,7 +59,7 @@ export async function POST(req: NextRequest) {
         numberOfEmployees: data.companyInformations.numberOfEmployees,
         location: data.companyInformations.location.city,
         featured: data.featured,
-        companyId: data.eid,
+        companyId: data.id,
       };
 
       data.openJobs.forEach((job: EmployerOpenJobs) => {

--- a/app/is-ilani/page.tsx
+++ b/app/is-ilani/page.tsx
@@ -9,7 +9,7 @@ import React from "react";
 import ApplicationModal from "@/components/pages/jobDetail/applicationModal/ApplicationModal";
 import { useSelector } from "react-redux";
 import { RootState } from "@/lib/redux/store";
-import { JobPostingAdditionalQuestions } from "@/types";
+import { JobPostingAdditionalQuestions } from "@/types/auth/employer/open-jobs.types";
 
 const JobDetail = () => {
   const params = useSearchParams();

--- a/components/pages/home/BestCompanies.tsx
+++ b/components/pages/home/BestCompanies.tsx
@@ -89,7 +89,7 @@ const BestCompanies = () => {
                   <FavoriteItem
                     data={{
                       dataField: {
-                        postID: company?.eid,
+                        postID: company?.id,
                         companyLocation:
                           company?.companyInformations?.location?.city,
                         numberOfEmployees:
@@ -97,7 +97,7 @@ const BestCompanies = () => {
                         companyLogo: company?.companyInformations?.companyLogo,
                         companyName: company?.companyInformations?.companyName,
                       },
-                      postID: company?.eid,
+                      postID: company?.id,
                     }}
                     fieldName={FavoriteField.Employers}
                   />
@@ -107,7 +107,7 @@ const BestCompanies = () => {
                   className="w-max mx-auto"
                   href={`/firma-profil/${routeFormatter(
                     company.companyInformations.companyName
-                  )}-${company.eid}`}
+                  )}-${company.id}`}
                 >
                   <Image
                     src={company.companyInformations.companyLogo}
@@ -121,7 +121,7 @@ const BestCompanies = () => {
                   <Link
                     href={`/firma-profil/${routeFormatter(
                       company.companyInformations.companyName
-                    )}-${company.eid}`}
+                    )}-${company.id}`}
                   >
                     {company.companyInformations.companyName}
                   </Link>
@@ -172,7 +172,7 @@ const BestCompanies = () => {
                     className="slide-button !w-full !h-full !py-[11px] !flex !items-center !justify-center !gap-[5px]"
                     href={`/firma-profil/${routeFormatter(
                       company.companyInformations.companyName
-                    )}-${company.eid}`}
+                    )}-${company.id}`}
                   >
                     {`Açık iş -
                   ${company.openJobs ? company.openJobs.length : 0}

--- a/components/pages/home/FeaturedJobs.tsx
+++ b/components/pages/home/FeaturedJobs.tsx
@@ -109,7 +109,7 @@ const FeaturedJobs = () => {
                       <p className="text-[15px] mt-2.5">
                         <Link
                           href={`firma-profil/${routeFormatter(
-                            `${job.companyInformations.companyName}-${job.eid}`
+                            `${job.companyInformations.companyName}-${job.id}`
                           )}`}
                         >
                           <strong className="featured-job-title-tag">

--- a/components/pages/jobDetail/applicationModal/ApplicationModal.tsx
+++ b/components/pages/jobDetail/applicationModal/ApplicationModal.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from "react";
 import ModalHeader from "./modalUI/ModalHeader";
 import ModalProgressBar from "./modalControls/ModalProgressBar";
 import ModalBody from "./modalBody/ModalBody";
-import { JobPostingAdditionalQuestions } from "@/types";
 import { useDispatch } from "react-redux";
 import { AppDispatch } from "@/lib/redux/store";
 import {
@@ -10,6 +9,7 @@ import {
   setProgressBarValue,
 } from "@/lib/redux/features/applicationModal/progressBar";
 import { setApplicationModal } from "@/lib/redux/features/touch";
+import { JobPostingAdditionalQuestions } from "@/types/auth/employer/open-jobs.types";
 
 const ApplicationModal = ({
   companyName,

--- a/components/pages/jobPostings/jobs/JobItem.tsx
+++ b/components/pages/jobPostings/jobs/JobItem.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/lib/redux/features/filterJobs/filters";
 import { AppDispatch, RootState } from "@/lib/redux/store";
 import { routeFormatter } from "@/lib/routeFormat";
-import { EmployerOpenJobs } from "@/types";
+import { EmployerOpenJobs } from "@/types/auth/employer/open-jobs.types";
 import { FavoriteField } from "@/types/favorite";
 import { JobCompanyInformations } from "@/types/filtersJob";
 import { UnknownAction } from "@reduxjs/toolkit";

--- a/components/pages/jobPostings/jobs/JobList.tsx
+++ b/components/pages/jobPostings/jobs/JobList.tsx
@@ -1,5 +1,4 @@
 import { useGetJobPostingsQuery } from "@/lib/redux/services/jobPostings";
-import { EmployerOpenJobs } from "@/types";
 import React from "react";
 import JobItem from "./JobItem";
 import { JobCompanyInformations } from "@/types/filtersJob";
@@ -11,6 +10,7 @@ import LoaderSkeleton from "@/components/ui/LoaderSkeleton";
 import { openFilterMenu } from "@/lib/redux/features/filterJobs/filters";
 import { TbAdjustmentsHorizontal } from "react-icons/tb";
 import JobPagination from "./JobPagination";
+import { EmployerOpenJobs } from "@/types/auth/employer/open-jobs.types";
 
 const JobList = () => {
   const { filterData, filtersItem } = useSelector(

--- a/constants/filtersJob.ts
+++ b/constants/filtersJob.ts
@@ -2,6 +2,7 @@ import { FilterSwitch, JobTypes } from "@/types/filtersJob";
 
 export const JOB_TYPES: JobTypes = [
   "Hibrit",
+  "Stajyer",
   "Freelance",
   "İş Yerinde",
   "Tam Zamanlı",

--- a/hooks/useFavoriteCompany.tsx
+++ b/hooks/useFavoriteCompany.tsx
@@ -16,12 +16,9 @@ const useFavoriteCompany = () => {
 
   useEffect(() => {
     if (candidateUser) {
-      const unsub = onSnapshot(
-        doc(db, "users", candidateUser?.id ?? candidateUser?.cid),
-        (doc) => {
-          setUpdatedData(doc.data() as Candidate);
-        }
-      );
+      const unsub = onSnapshot(doc(db, "users", candidateUser?.id), (doc) => {
+        setUpdatedData(doc.data() as Candidate);
+      });
 
       return () => unsub();
     }

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -22,7 +22,7 @@ export const SignInWithGooglePopup = async () => {
       document.cookie = `VV9SVA=${btoa(credential.user.refreshToken)}`;
 
       const createdData = {
-        cid: credential.user.uid,
+        id: credential.user.uid,
         displayName: credential.user.displayName,
         acceptedTerms: `${credential.user.displayName} adlı Kullanıcı, kullanım şartlarını kabul ettiğini ve bu şartlara uygun hareket edeceğini beyan eder.`,
         email: credential.user.email,

--- a/lib/redux/features/filterJobs/filters.ts
+++ b/lib/redux/features/filterJobs/filters.ts
@@ -1,4 +1,4 @@
-import { EmployerOpenJobs } from "@/types";
+import { EmployerOpenJobs } from "@/types/auth/employer/open-jobs.types";
 import {
   FilterArrayFields,
   FilterPaginationFields,

--- a/lib/redux/services/bestCompaniesApi.ts
+++ b/lib/redux/services/bestCompaniesApi.ts
@@ -1,4 +1,4 @@
-import { Employer } from "@/types";
+import { Employer } from "@/types/auth/models/employer";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 export const bestCompaniesApi = createApi({

--- a/lib/redux/services/featuredJobsApi.ts
+++ b/lib/redux/services/featuredJobsApi.ts
@@ -1,4 +1,4 @@
-import { Employer } from "@/types";
+import { Employer } from "@/types/auth/models/employer";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 export const featuredJobsApi = createApi({

--- a/lib/redux/services/jobDetail.ts
+++ b/lib/redux/services/jobDetail.ts
@@ -1,4 +1,4 @@
-import { EmployerOpenJobs } from "@/types";
+import { EmployerOpenJobs } from "@/types/auth/employer/open-jobs.types";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 export const jobDetailApi = createApi({

--- a/types/auth/employer/open-jobs.types.ts
+++ b/types/auth/employer/open-jobs.types.ts
@@ -1,0 +1,43 @@
+/**
+ * @description the interface of the job opened by the employer
+ */
+
+import { Timestamp } from "firebase/firestore";
+
+type ExperienceTime =
+  | "Deneyimli"
+  | "Deneyimsiz"
+  | "1 Yıl"
+  | "2 Yıl"
+  | "3 Yıl"
+  | "4 Yıl"
+  | "5 Yıl"
+  | "5+ Yıl";
+
+export interface EmployerOpenJobs {
+  postId: string;
+  jobTitle: string;
+  jobAbout: string;
+  category: string;
+  modeOfWork: string;
+  workModel: string;
+  positionLevel: string;
+  educationLevel: string[];
+  experienceTime: ExperienceTime;
+  applicationDeadlineDate: string;
+  location: string;
+  datePosted: Timestamp;
+  additionalQuestions: JobPostingAdditionalQuestions;
+}
+
+export interface JobPostingAdditionalQuestions {
+  isSelectAnswer: boolean;
+  isTextAnswer: boolean;
+  selectQuestions: {
+    questionAnswers: string[];
+    questionTitle: string;
+  }[];
+  textQuestions: {
+    questionTitle: string;
+  }[];
+}

--- a/types/auth/employer/signup-form.types.ts
+++ b/types/auth/employer/signup-form.types.ts
@@ -1,0 +1,15 @@
+//? employer sign up form fields ?//
+export interface EmployerSignupFormFields {
+  nameAndSurname: string;
+  phone: string;
+  email: string;
+  password: string;
+  companyName: string;
+  taxNumber: string;
+  checkboxFirst: boolean;
+  checkboxSecond: boolean;
+  city: string;
+  district: string;
+  taxCity: string;
+  taxOffice: string;
+}

--- a/types/auth/models/employer.ts
+++ b/types/auth/models/employer.ts
@@ -1,0 +1,32 @@
+import { User } from "../..";
+import { EmployerOpenJobs } from "../employer/open-jobs.types";
+
+/**
+ * @interface Employer
+ * @extends User
+ * @description The user data stored in DB for users with employer role
+ */
+export interface Employer extends User {
+  companyInformations: CompanyInformations;
+  featured: boolean;
+  bestCompany: boolean;
+  openJobs: EmployerOpenJobs[];
+}
+
+export interface Location {
+  city: string;
+  district: string;
+  taxNumber: string;
+  taxOffice: string;
+  taxOfficeCity: string;
+}
+
+export interface CompanyInformations {
+  companyName: string;
+  companyLogo: string;
+  email: string;
+  serviceArea: string;
+  phoneNumber: string;
+  numberOfEmployees: string;
+  location: Location;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,4 +1,3 @@
-import { Timestamp } from "firebase/firestore";
 import { FormikErrors } from "formik";
 import { ChangeEvent, InputHTMLAttributes, ReactNode } from "react";
 import { CVDataFields } from "./resume";
@@ -72,21 +71,6 @@ export interface AuthSelectProps {
   labelClass?: string;
 }
 
-export interface EmployerSignupFormFields {
-  nameAndSurname: string;
-  phone: string;
-  email: string;
-  password: string;
-  companyName: string;
-  taxNumber: string;
-  checkboxFirst: boolean;
-  checkboxSecond: boolean;
-  selectCity: string;
-  selectDistricts: string;
-  selectTaxOfficiesCity: string;
-  selectTaxOffice: string;
-}
-
 export interface AuthCheckboxProps {
   errors?: string | undefined;
   values: boolean;
@@ -153,55 +137,6 @@ export interface User {
   role: string;
 }
 
-export interface EmployerOpenJobs {
-  postId: string;
-  jobTitle: string;
-  jobAbout: string;
-  category: string;
-  modeOfWork: string;
-  workModel: string;
-  positionLevel: string;
-  educationLevel: string[];
-  experienceTime: string;
-  applicationDeadlineDate: string;
-  location: string;
-  datePosted: Timestamp;
-  additionalQuestions: JobPostingAdditionalQuestions;
-}
-
-export interface JobPostingAdditionalQuestions {
-  isSelectAnswer: boolean;
-  isTextAnswer: boolean;
-  selectQuestions: {
-    questionAnswers: string[];
-    questionTitle: string;
-  }[];
-  textQuestions: {
-    questionTitle: string;
-  }[];
-}
-
-export interface Employer extends User {
-  eid: string;
-  companyInformations: {
-    companyName: string;
-    companyLogo: string;
-    serviceArea: string;
-    phoneNumber: string;
-    numberOfEmployees: string;
-    location: {
-      city: string;
-      district: string;
-      taxNumber: string;
-      taxOffice: string;
-      taxOfficieCity: string;
-    };
-  };
-  featured: boolean;
-  bestCompany: boolean;
-  openJobs: EmployerOpenJobs[];
-}
-
 export interface CandidateFavoriteInterface {
   postID: string;
   companyLocation: string;
@@ -211,7 +146,7 @@ export interface CandidateFavoriteInterface {
 }
 
 export interface Candidate extends User {
-  cid: string;
+  id: string;
   acceptedTerms: string;
   createdWith: string;
   favoriteEmployers: CandidateFavoriteInterface[];

--- a/types/jobDetail.ts
+++ b/types/jobDetail.ts
@@ -1,4 +1,4 @@
-import { EmployerOpenJobs } from ".";
+import { EmployerOpenJobs } from "./auth/employer/open-jobs.types";
 
 //? Job detail page top intro section interfaces ?//
 export interface JobIntroInterface {


### PR DESCRIPTION
## Summary

This refactor improves the structure of employer-related type definitions and signup form fields to ensure consistency, scalability, and better type safety across the application.

---

## ✨ Changes

- Removed `Employer` interface export from `types/index.ts`
- Created `types/models/` directory for user-role-specific interfaces
- Moved:
  - employer open job types
  - employer signup form field types  
  → to `types/auth/employer/`
- Replaced deprecated `eid` prop with `id` in:
  - `BestCompanies` component
  - `FeaturedJobs` component
- Updated all related import paths in:
  - `is-ilani` route
  - `filters` slice
  - `bestCompaniesApi`, `featuredJobsApi`, `jobDetailApi`
  - `jobDetail` type file
  - `api/firebase/employers`
  - `api/firebase/job-detail`
  - `api/firebase/job-postings`
  - `ApplicationModal`, `JobItem`, `JobList` components
- Renamed form fields in `EmployerForm` for clarity and reusability:
  - `selectCity` → `city`
  - `selectDistricts` → `district`
  - `selectTaxOfficiesCity` → `taxCity`
  - `selectTaxOffice` → `taxOffice`
- Updated `EmployerSignupSchema` validation accordingly