### PR TITLE
feat(resume): add PDF loading placeholder indicator with progress spinner

### DIFF
--- a/components/pages/jobDetail/applicationModal/modalBody/resume/ResumeList.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/ResumeList.tsx
@@ -9,6 +9,7 @@ import {
   setUploadedFileNames,
 } from "@/lib/redux/features/applicationModal/modalData";
 import ShowMoreResumes from "./ShowMoreResumes";
+import PdfLoadingOverlay from "./resumeItem/PdfLoadingOverlay";
 
 const ResumeList = () => {
   const { user } = useContext(AuthContext);
@@ -22,10 +23,13 @@ const ResumeList = () => {
     docID: user?.id ?? "",
     cvID: cvID,
   });
+
   const resumeData = useMemo(() => data?.resumeData ?? [], [data?.resumeData]);
-  const findMatchUpload = resumeData.find(
-    (resume) => resume.fileName == placeholderUploadData.fileName
-  );
+  const findMatchUpload = useMemo(() => {
+    return resumeData.find(
+      (resume) => resume.fileName == placeholderUploadData.fileName
+    );
+  }, [placeholderUploadData.fileName, resumeData]);
 
   useEffect(() => {
     if (findMatchUpload) {
@@ -44,11 +48,9 @@ const ResumeList = () => {
   return (
     <div className="px-6 mb-4 mt-2">
       <ul>
-        {/* ↓ this section will then use the placeholder resume element. (currently temporary) ↓ */}
-        {!findMatchUpload && placeholderUploadData.fileName.length
-          ? "Özgeçmiş yükleniyor.."
-          : ""}
-        {/* ↑ this section will then use the placeholder resume element. (currently temporary) ↑ */}
+        {!findMatchUpload && !!placeholderUploadData.fileName.length && (
+          <PdfLoadingOverlay />
+        )}
 
         {resumeData.slice(0, 2).map((resume) => (
           <ResumeItem key={resume.cvID} resume={resume} />

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/PdfLoadingOverlay.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/PdfLoadingOverlay.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import ResumeItem from "../ResumeItem";
+import { useSelector } from "react-redux";
+import { RootState } from "@/lib/redux/store";
+import { calculateCVSize } from "@/lib/utils/calculateCvSize";
+import CircularProgress from "@mui/material/CircularProgress";
+import Box from "@mui/material/Box";
+
+const PdfLoadingOverlay = () => {
+  const { fileName, size, uploadTime } = useSelector(
+    (state: RootState) => state.applicationModalData.placeholderUploadData
+  );
+
+  return (
+    <div className="relative">
+      <Box
+        sx={{
+          display: "grid",
+          placeContent: "center",
+          zIndex: 10,
+          width: "100%",
+          height: "100%",
+          position: "absolute",
+          top: "0",
+          left: "0",
+        }}
+      >
+        <CircularProgress
+          sx={{ color: "#99a1af" }}
+          size={30}
+          aria-label="Loading PDF"
+          data-testid="Loading PDF"
+        />
+      </Box>
+
+      <div className="opacity-70">
+        <ResumeItem
+          resume={{
+            fileName,
+            size: calculateCVSize(size),
+            uploadTime,
+            createdAt: "",
+            cvID: "",
+            url: "",
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PdfLoadingOverlay;


### PR DESCRIPTION
This PR introduces a PDF loading placeholder indicator to improve user experience during resume uploads. 

- Created `PdfLoadingOverlay` component that displays a loading spinner (Material UI CircularProgress) over a semi-transparent preview of the resume item.
- Used `useMemo` to optimize `findMatchUpload` calculation by caching the result between re-renders, improving performance.
- Integrated the `PdfLoadingOverlay` component into the `ResumeList` component and conditionally render it when PDF upload is in progress.

These changes provide clearer visual feedback during PDF uploads, enhancing responsiveness and UX.