### PR TITLE
feat(resume): replace 4th resume when 5th is uploaded with API integration

### DIFF
--- a/app/api/resume/delete-last-resume/route.ts
+++ b/app/api/resume/delete-last-resume/route.ts
@@ -1,0 +1,34 @@
+import { arrayRemove, doc, getDoc, updateDoc } from "firebase/firestore";
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "../../firebase/firebaseConfig";
+import { CVDataFields } from "@/types/resume";
+
+export async function POST(req: NextRequest) {
+  const { lastResumeName, userID } = await req.json();
+
+  try {
+    const deleteLastResumeToDB = async (collection: string) => {
+      const docRef = doc(db, collection, userID);
+      const docSnap = await getDoc(docRef);
+      const uploadedResumes: CVDataFields[] = docSnap.data()?.uploadedResumes;
+      const findRemoveData = uploadedResumes.find(
+        (resume) => resume.fileName === lastResumeName
+      );
+
+      await updateDoc(docRef, {
+        uploadedResumes: arrayRemove(findRemoveData),
+      });
+    };
+
+    await Promise.all([
+      deleteLastResumeToDB("users"),
+      deleteLastResumeToDB("candidates"),
+    ]);
+
+    return NextResponse.json({ message: "Resume deleted successfully." });
+  } catch (error) {
+    if (error instanceof Error) {
+      return NextResponse.json({ message: error.message }, { status: 400 });
+    }
+  }
+}

--- a/app/api/resume/upload-resume/route.ts
+++ b/app/api/resume/upload-resume/route.ts
@@ -5,6 +5,7 @@ import { db } from "../../firebase/firebaseConfig";
 import { UploadedCV } from "@/types/resume";
 import dayjs from "dayjs";
 import { calculateCVSize } from "@/lib/utils/calculateCvSize";
+import appendFormData from "@/lib/utils/appendFormData";
 
 export async function POST(req: NextRequest) {
   const formData = await req.formData();
@@ -18,12 +19,13 @@ export async function POST(req: NextRequest) {
       file.type === "application/pdf" &&
       file.size <= 3 * 1024 * 1024
     ) {
-      const formData = new FormData();
-      formData.append("file", file);
-      formData.append(
-        "upload_preset",
-        process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET as string
-      );
+      const formData = appendFormData([
+        { name: "file", value: file },
+        {
+          name: "upload_preset",
+          value: process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET as string,
+        },
+      ]);
 
       //? upload pdf to cloudinary ?//
       const apiURL = `https://api.cloudinary.com/v1_1/${process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME}/auto/upload`;

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/ResumeList.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/ResumeList.tsx
@@ -9,6 +9,7 @@ import {
   setUploadedFileNames,
 } from "@/lib/redux/features/applicationModal/modalData";
 import ShowMoreResumes from "./ShowMoreResumes";
+import PdfLoadingOverlay from "./resumeItem/PdfLoadingOverlay";
 
 const ResumeList = () => {
   const { user } = useContext(AuthContext);
@@ -22,10 +23,13 @@ const ResumeList = () => {
     docID: user?.id ?? "",
     cvID: cvID,
   });
+
   const resumeData = useMemo(() => data?.resumeData ?? [], [data?.resumeData]);
-  const findMatchUpload = resumeData.find(
-    (resume) => resume.fileName == placeholderUploadData.fileName
-  );
+  const findMatchUpload = useMemo(() => {
+    return resumeData.find(
+      (resume) => resume.fileName == placeholderUploadData.fileName
+    );
+  }, [placeholderUploadData.fileName, resumeData]);
 
   useEffect(() => {
     if (findMatchUpload) {
@@ -44,11 +48,9 @@ const ResumeList = () => {
   return (
     <div className="px-6 mb-4 mt-2">
       <ul>
-        {/* ↓ this section will then use the placeholder resume element. (currently temporary) ↓ */}
-        {!findMatchUpload && placeholderUploadData.fileName.length
-          ? "Özgeçmiş yükleniyor.."
-          : ""}
-        {/* ↑ this section will then use the placeholder resume element. (currently temporary) ↑ */}
+        {!findMatchUpload && !!placeholderUploadData.fileName.length && (
+          <PdfLoadingOverlay />
+        )}
 
         {resumeData.slice(0, 2).map((resume) => (
           <ResumeItem key={resume.cvID} resume={resume} />

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/UploadResume.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/UploadResume.tsx
@@ -1,30 +1,28 @@
-import React, { ChangeEvent, useContext, useRef, useState } from "react";
+import React, { ChangeEvent, useContext, useRef } from "react";
 import InformationMessage from "../../modalUI/InformationMessage";
 import { useDispatch, useSelector } from "react-redux";
-import { AppDispatch, RootState, store } from "@/lib/redux/store";
+import { AppDispatch, RootState } from "@/lib/redux/store";
 import { Form, Formik } from "formik";
 import ModalControls from "../../modalControls/ModalControls";
-import {
-  setApplicationData,
-  setPlaceholderUploadData,
-} from "@/lib/redux/features/applicationModal/modalData";
 import { ResumeSchema } from "@/app/(auth)/schema/ApplicationModal/ResumeSchema";
 import validatePdfFile from "@/lib/utils/validatePdfFile";
-import { useUploadResumeMutation } from "@/lib/redux/services/resumeApi";
 import { AuthContext } from "@/context/authContext";
-import { nanoid } from "@reduxjs/toolkit";
-import { setCvID } from "@/lib/redux/features/applicationModal/cvIdSlice";
-import dayjs from "dayjs";
+import useUploadResume from "@/hooks/useUploadResume";
+import { useDeleteLastResumeMutation } from "@/lib/redux/services/resumeApi";
+import { setPdfErrorMessage } from "@/lib/redux/features/applicationModal/modalData";
 
 const UploadResume = () => {
-  const { applicationData, uploadedFileNames } = useSelector(
-    (state: RootState) => state.applicationModalData
-  );
-  const dispatch = useDispatch<AppDispatch>();
-  const [pdfMessage, setPdfMessage] = useState<string>("");
-  const [uploadResume] = useUploadResumeMutation();
+  const {
+    applicationData,
+    uploadedFileNames,
+    placeholderUploadData: { fileName },
+    PdfErrorMessage,
+  } = useSelector((state: RootState) => state.applicationModalData);
   const { user } = useContext(AuthContext);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const { uploadResumeToApi } = useUploadResume();
+  const [deleteLastResume] = useDeleteLastResumeMutation();
+  const dispatch = useDispatch<AppDispatch>();
 
   const handleUploadResume = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -36,37 +34,24 @@ const UploadResume = () => {
     ) {
       const isValidFile = await validatePdfFile(file);
       if (!isValidFile) {
-        setPdfMessage(
-          "PDF dosyası geçersiz ya da bozuk lütfen başka bir dosya yükleyin"
+        dispatch(
+          setPdfErrorMessage(
+            "PDF dosyası geçersiz ya da bozuk lütfen başka bir dosya yükleyin"
+          )
         );
       } else if (uploadedFileNames.includes(file.name)) {
-        setPdfMessage("Bu dosyayı zaten yüklediniz");
+        dispatch(setPdfErrorMessage("Bu dosyayı zaten yüklediniz"));
       } else if (uploadedFileNames.length > 3) {
-        setPdfMessage("En fazla 4 tane yükleyebilirsiniz");
+        await Promise.all([
+          deleteLastResume({
+            lastResumeName: uploadedFileNames[0],
+            userID: user?.id ?? "",
+          }),
+
+          uploadResumeToApi(file, user?.id ?? ""),
+        ]);
       } else {
-        dispatch(
-          setPlaceholderUploadData({
-            fileName: file.name,
-            size: file.size,
-            uploadTime: dayjs().format("DD.MM.YYYY"),
-          })
-        );
-
-        setPdfMessage("");
-        dispatch(setCvID(nanoid()));
-        const { cvID } = store.getState().cvIdSlice;
-        const formData = new FormData();
-        formData.append("file", file);
-        formData.append("docID", user?.id ?? "");
-        formData.append("cvID", cvID);
-        const { data } = await uploadResume(formData);
-
-        dispatch(
-          setApplicationData({
-            ...applicationData,
-            resume: data?.resumeData?.secure_url,
-          })
-        );
+        await uploadResumeToApi(file, user?.id ?? "");
       }
 
       if (fileInputRef.current) {
@@ -109,16 +94,17 @@ const UploadResume = () => {
                   handleUploadResume(e);
                 }}
                 ref={fileInputRef}
+                disabled={!!fileName.length}
               />
               <div className="text-[#D91B1B] text-[15px] mt-1">
-                {errors.resume ? errors.resume : pdfMessage}
+                {errors.resume ? errors.resume : PdfErrorMessage}
               </div>
             </div>
 
             <InformationMessage />
             <ModalControls
               isErrors={Object.keys(
-                pdfMessage?.length ? { pdfMessage } : errors
+                PdfErrorMessage?.length ? { PdfErrorMessage } : errors
               )}
               formValues={values}
             />

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/PdfLoadingOverlay.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/PdfLoadingOverlay.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import ResumeItem from "../ResumeItem";
+import { useSelector } from "react-redux";
+import { RootState } from "@/lib/redux/store";
+import { calculateCVSize } from "@/lib/utils/calculateCvSize";
+import CircularProgress from "@mui/material/CircularProgress";
+import Box from "@mui/material/Box";
+
+const PdfLoadingOverlay = () => {
+  const { fileName, size, uploadTime } = useSelector(
+    (state: RootState) => state.applicationModalData.placeholderUploadData
+  );
+
+  return (
+    <div className="relative">
+      <Box
+        sx={{
+          display: "grid",
+          placeContent: "center",
+          zIndex: 10,
+          width: "100%",
+          height: "100%",
+          position: "absolute",
+          top: "0",
+          left: "0",
+        }}
+      >
+        <CircularProgress
+          sx={{ color: "#99a1af" }}
+          size={30}
+          aria-label="Loading PDF"
+          data-testid="Loading PDF"
+        />
+      </Box>
+
+      <div className="opacity-70">
+        <ResumeItem
+          resume={{
+            fileName,
+            size: calculateCVSize(size),
+            uploadTime,
+            createdAt: "",
+            cvID: "",
+            url: "",
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PdfLoadingOverlay;

--- a/hooks/useUploadResume.tsx
+++ b/hooks/useUploadResume.tsx
@@ -1,0 +1,59 @@
+import { setCvID } from "@/lib/redux/features/applicationModal/cvIdSlice";
+import {
+  clearPlaceholderUploadData,
+  setPdfErrorMessage,
+  setPlaceholderUploadData,
+} from "@/lib/redux/features/applicationModal/modalData";
+import { useUploadResumeMutation } from "@/lib/redux/services/resumeApi";
+import { AppDispatch, store } from "@/lib/redux/store";
+import appendFormData from "@/lib/utils/appendFormData";
+import { nanoid } from "@reduxjs/toolkit";
+import dayjs from "dayjs";
+import { useCallback } from "react";
+import toast from "react-hot-toast";
+import { useDispatch } from "react-redux";
+
+const useUploadResume = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const [uploadResume] = useUploadResumeMutation();
+
+  const uploadResumeToApi = useCallback(
+    async (file: File, docID: string): Promise<void> => {
+      try {
+        dispatch(setPdfErrorMessage(""));
+
+        dispatch(
+          setPlaceholderUploadData({
+            fileName: file.name,
+            size: file.size,
+            uploadTime: dayjs().format("DD.MM.YYYY"),
+          })
+        );
+
+        dispatch(setCvID(nanoid()));
+        const { cvID } = store.getState().cvIdSlice;
+
+        const formData = appendFormData([
+          { name: "file", value: file },
+          { name: "docID", value: docID },
+          { name: "cvID", value: cvID },
+        ]);
+
+        await uploadResume(formData).unwrap();
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (error) {
+        dispatch(clearPlaceholderUploadData());
+        dispatch(setPdfErrorMessage(""));
+        toast.error(
+          "Özgeçmiş yüklenemedi. Lütfen bağlantınızı kontrol edip tekrar deneyin."
+        );
+      }
+    },
+    [dispatch, uploadResume]
+  );
+
+  return { uploadResumeToApi };
+};
+
+export default useUploadResume;

--- a/lib/redux/features/applicationModal/modalData.ts
+++ b/lib/redux/features/applicationModal/modalData.ts
@@ -16,6 +16,7 @@ interface initialStateFields {
     uploadTime: string;
   };
   uploadedFileNames: string[];
+  PdfErrorMessage: string;
 }
 
 const initialState: initialStateFields = {
@@ -33,6 +34,7 @@ const initialState: initialStateFields = {
   },
 
   uploadedFileNames: [],
+  PdfErrorMessage: "",
 };
 
 export const applicationModalDataSlice = createSlice({
@@ -68,8 +70,16 @@ export const applicationModalDataSlice = createSlice({
       state.placeholderUploadData = action.payload;
     },
 
+    clearPlaceholderUploadData: (state) => {
+      state.placeholderUploadData = initialState.placeholderUploadData;
+    },
+
     setUploadedFileNames: (state, action: PayloadAction<string[]>) => {
       state.uploadedFileNames = action.payload;
+    },
+
+    setPdfErrorMessage: (state, action: PayloadAction<string>) => {
+      state.PdfErrorMessage = action.payload;
     },
   },
 });
@@ -78,4 +88,6 @@ export const {
   setApplicationData,
   setPlaceholderUploadData,
   setUploadedFileNames,
+  clearPlaceholderUploadData,
+  setPdfErrorMessage,
 } = applicationModalDataSlice.actions;

--- a/lib/redux/services/resumeApi.ts
+++ b/lib/redux/services/resumeApi.ts
@@ -17,6 +17,7 @@ export const resumeApi = createApi({
         return [{ type: "Resume", id: String(cvID) as string }];
       },
     }),
+
     fetchResume: builder.query<
       { resumeData: CVDataFields[] },
       { docID: string; cvID: string }
@@ -26,7 +27,26 @@ export const resumeApi = createApi({
         { type: "Resume", id: cvID },
       ],
     }),
+
+    deleteLastResume: builder.mutation<
+      { message: string },
+      { lastResumeName: string; userID: string }
+    >({
+      query: ({ lastResumeName, userID }) => ({
+        url: "delete-last-resume",
+        method: "POST",
+        body: {
+          lastResumeName,
+          userID,
+        },
+      }),
+      invalidatesTags: ["Resume"],
+    }),
   }),
 });
 
-export const { useUploadResumeMutation, useFetchResumeQuery } = resumeApi;
+export const {
+  useUploadResumeMutation,
+  useFetchResumeQuery,
+  useDeleteLastResumeMutation,
+} = resumeApi;

--- a/lib/utils/appendFormData.ts
+++ b/lib/utils/appendFormData.ts
@@ -1,0 +1,18 @@
+type AppendData = { name: string; value: string | Blob };
+
+/**
+ * Creates and returns a `FormData` instance from an array of
+ * `{ name, value }` pairs.
+ *
+ * @param {AppendData[]} appendData – Array of objects where
+ *        `name` is a string and `value` is either a string or a Blob/File.
+ * @returns {FormData} The populated FormData object.
+ */
+
+const appendFormData = (appendData: AppendData[]): FormData => {
+  const formData = new FormData();
+  appendData.forEach(({ name, value }) => formData.append(name, value));
+  return formData;
+};
+
+export default appendFormData;


### PR DESCRIPTION
This PR implements the feature to automatically replace the 4th uploaded resume when a 5th resume is uploaded, ensuring the maximum of 4 resumes is maintained.

- Created a new API route `delete-last-resume` to handle deletion of the last resume on the backend.
- Extracted `useUploadResume` custom hook for better reusability and removed upload logic from the `UploadResume` component.
- Added `deleteLastResume` endpoint to the `resumeApi` service and integrated it with the new backend route.
- Added reducers `clearPlaceholderUploadData` and `setPdfErrorMessage` to `applicationModalDataSlice` for better state management.
- Created a reusable `appendFormData` utility function under the `utils` folder for consistent FormData handling.
- Integrated `appendFormData` utility within the `upload-resume` API route and the `useUploadResume` hook to streamline file upload operations.

These changes improve resume upload handling by enforcing upload limits and enhancing code modularity and error management.