### PR TITLE
test: add unit tests for UploadResume component and improve testability

### DIFF
--- a/components/__tests__/UploadResume.test.tsx
+++ b/components/__tests__/UploadResume.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import UploadResume from "../pages/jobDetail/applicationModal/modalBody/resume/UploadResume";
+import { Provider } from "react-redux";
+import { testStore } from "../../lib/utils/testStore";
+import userEvent from "@testing-library/user-event";
+import { Store } from "@reduxjs/toolkit";
+import React, { ReactElement } from "react";
+import { store as realStore } from "@/lib/redux/store";
+import ResumeInput from "../pages/jobDetail/applicationModal/modalBody/resume/uploadResume/ResumeInput";
+
+jest.mock("../../app/api/firebase/firebaseConfig", () => ({
+  auth: {},
+  db: {},
+  provider: {
+    setCustomParameters: jest.fn(),
+  },
+}));
+
+jest.mock("../../lib/utils/validateResume");
+
+const user = userEvent.setup();
+
+const renderComponent = (component: ReactElement, store?: Store) => {
+  render(<Provider store={store ?? realStore}>{component}</Provider>);
+};
+
+describe("UploadResume Component", () => {
+  describe("Static Texts", () => {
+    test("should render static texts", () => {
+      renderComponent(<UploadResume />);
+      expect(screen.getByText(/Özgeçmiş yükle/i)).toBeInTheDocument();
+      expect(screen.getByText("PDF (3 MB)")).toBeInTheDocument();
+      expect(
+        screen.getByText(/bu başvurunun gönderilmesi/i)
+      ).toBeInTheDocument();
+      expect(screen.getByText("İleri")).toBeInTheDocument();
+    });
+  });
+
+  describe("Validation", () => {
+    test("displays error message when user proceeds without selecting a resume", async () => {
+      const store = testStore({
+        applicationModalData: {
+          uploadedFileNames: ["1.pdf"],
+          selectedResume: "0",
+          resumeErrorMessage: "",
+          placeholderUploadData: {
+            fileName: "",
+          },
+        },
+      });
+
+      renderComponent(<UploadResume />, store);
+
+      const button = screen.getByText("İleri");
+      await user.click(button);
+
+      expect(screen.getByText("Lütfen bir özgeçmiş seçin")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Lütfen bir özgeçmiş (CV) dosyası yükleyin")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("File Upload Behavior", () => {
+    test("should update file name on input change", async () => {
+      const mockSetFileValue = jest.fn();
+      const file = new File(["file"], "test.pdf", { type: "application/pdf" });
+
+      renderComponent(<ResumeInput setFileValue={mockSetFileValue} />);
+
+      const input = screen.getByTestId("resume-upload-input");
+      await user.upload(input, file);
+
+      expect(mockSetFileValue).toHaveBeenCalledWith("test.pdf");
+    });
+  });
+});

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/uploadResume/ResumeInput.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/uploadResume/ResumeInput.tsx
@@ -57,8 +57,11 @@ const ResumeInput = ({
         hidden
         onChange={handleUploadResume}
         disabled={Boolean(fileName)}
+        data-testid="resume-upload-input"
       />
-      <div className="text-[#D91B1B] text-[15px] mt-1">{resumeErrorMessage}</div>
+      <div className="text-[#D91B1B] text-[15px] mt-1">
+        {resumeErrorMessage}
+      </div>
     </>
   );
 };

--- a/lib/utils/testStore.ts
+++ b/lib/utils/testStore.ts
@@ -1,0 +1,13 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { applicationModalDataSlice } from "../redux/features/applicationModal/modalData";
+import { ProgressBarSlice } from "../redux/features/applicationModal/progressBar";
+
+export const testStore = (preloadedState = {}) => {
+  return configureStore({
+    reducer: {
+      applicationModalData: applicationModalDataSlice.reducer,
+      applicationModalProgressBar: ProgressBarSlice.reducer,
+    },
+    preloadedState,
+  });
+};


### PR DESCRIPTION
## Description

This PR introduces unit tests for the `UploadResume` component using Testing Library and Jest. The goal is to ensure static content renders correctly, validation behaves as expected, and file upload input works as intended.  
To support file input testing, a `data-testid` attribute has been added to the input element inside the `ResumeInput` component.

---

## 🔧 What’s Added

- ✅ **Mocked** Firebase config (`auth`, `db`, `provider`) to isolate external dependencies
- ✅ **Mocked** `validateResume` utility to avoid triggering real validation logic
- ✅ **Created** a reusable `renderComponent` helper with optional store override
- ✅ **Test cases written** in `UploadResume.test.tsx`:
  
  ### 📄 Static Text Tests
  - Verifies that UI renders expected static texts such as:
    - `Özgeçmiş yükle`
    - `PDF (3 MB)`
    - Legal disclaimer
    - `İleri` button

  ### ⚠️ Validation Test
  - Simulates clicking the `İleri` button without selecting a resume
  - Verifies that the proper validation error message (`Lütfen bir özgeçmiş seçin`) appears

  ### 📁 File Upload Test
  - Uses `ResumeInput` component in isolation
  - Simulates selecting a PDF file
  - Asserts that the `setFileValue` callback is triggered with the correct file name

---

## 🔧 Dev Notes

- `testStore` utility is used to inject custom Redux state and simulate real user flows
- The Firebase config is mocked to avoid initializing actual Firebase instances in test environment
- The `ResumeInput` component has been updated to include `data-testid="resume-upload-input"` for reliable targeting during tests

---

## 🧪 Tech Stack

- [`@testing-library/react`](https://testing-library.com/)
- [Jest](https://jestjs.io/)
- [Redux Toolkit](https://redux-toolkit.js.org/)
- `userEvent` for simulating realistic user interactions

---

## ✅ Checklist

- [x] Tests run successfully in isolation
- [x] File input is fully testable with `data-testid`
- [x] Redux state mocking works as expected
- [x] No production logic was changed

---

## ✅ Test Output

```bash
 PASS  components/__tests__/UploadResume.test.tsx
  UploadResume Component
    Static Texts
      ✓ should render static texts (32 ms)
    Validation
      ✓ displays error message when user proceeds without selecting a resume (88 ms)
    File Upload Behavior
      ✓ should update file name on input change (47 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        2.423 s
