### PR TITLE
feat(application-modal): reset modal state on unmount and improve scroll behavior

### DIFF
--- a/app/is-ilani/page.tsx
+++ b/app/is-ilani/page.tsx
@@ -10,7 +10,11 @@ import ApplicationModal from "@/components/pages/jobDetail/applicationModal/Appl
 import { useDispatch, useSelector } from "react-redux";
 import { AppDispatch, RootState } from "@/lib/redux/store";
 import { JobPostingAdditionalQuestions } from "@/types/auth/employer/open-jobs.types";
-import { setAdditionalQuestionsFromJob } from "@/lib/redux/features/applicationModal/modalData";
+import {
+  setAdditionalQuestionsFromJob,
+  setApplicationData,
+} from "@/lib/redux/features/applicationModal/modalData";
+import { setApplicationModal } from "@/lib/redux/features/touch";
 
 const JobDetail = () => {
   const params = useSearchParams();
@@ -30,6 +34,21 @@ const JobDetail = () => {
       dispatch(setAdditionalQuestionsFromJob(additionalQuestionsFromJob));
     }
   }, [data?.job.additionalQuestions, dispatch]);
+
+  useEffect(() => {
+    return () => {
+      dispatch(setApplicationModal(false));
+      dispatch(
+        setApplicationData({
+          additionalQuestions: [],
+          email: "",
+          phone: "",
+          resume: "",
+        })
+      );
+      dispatch(setAdditionalQuestionsFromJob({}));
+    };
+  }, [dispatch]);
 
   return (
     <main>

--- a/components/pages/jobDetail/applicationModal/ApplicationModal.tsx
+++ b/components/pages/jobDetail/applicationModal/ApplicationModal.tsx
@@ -2,8 +2,8 @@ import React, { useEffect } from "react";
 import ModalHeader from "./modalUI/ModalHeader";
 import ModalProgressBar from "./modalControls/ModalProgressBar";
 import ModalBody from "./modalBody/ModalBody";
-import { useDispatch } from "react-redux";
-import { AppDispatch } from "@/lib/redux/store";
+import { useDispatch, useSelector } from "react-redux";
+import { AppDispatch, RootState } from "@/lib/redux/store";
 import {
   setIsAdditionalQuestions,
   setProgressBarValue,
@@ -21,6 +21,9 @@ const ApplicationModal = ({
   additionalQuestions: JobPostingAdditionalQuestions;
 }) => {
   const dispatch = useDispatch<AppDispatch>();
+  const modalStep = useSelector(
+    (state: RootState) => state.applicationModalProgressBar.modalStep
+  );
 
   const handleCloseModal = () => {
     dispatch(setApplicationModal(false));
@@ -43,12 +46,21 @@ const ApplicationModal = ({
       onClick={handleCloseModal}
     >
       <div
-        className="bg-white fixed left-1/2 top-[32px] -translate-x-1/2 rounded-lg w-[744px] max-md:w-[95%]  max-sm:h-[500px] max-sm:overflow-auto"
+        className="bg-white fixed left-1/2 top-[2rem] -translate-x-1/2 rounded-lg w-[46.5rem] max-md:w-[95%]"
         onClick={(e) => e.stopPropagation()}
       >
         <ModalHeader companyName={companyName} jobTitle={jobTitle} />
-        <ModalProgressBar />
-        <ModalBody />
+
+        <div
+          className={
+            modalStep === 4
+              ? "h-[500px] overflow-auto"
+              : "max-sm:h-[500px] max-sm:overflow-auto"
+          }
+        >
+          <ModalProgressBar />
+          <ModalBody />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 📝  Description

This PR ensures the application modal state is reset when navigating away from the job detail page, and improves the scroll handling logic inside the modal.

🔧 What’s Changed

✅ `applicationModal` state is now reset on unmount of the `is-ilani` component, preventing stale or incorrect data from persisting between job detail views.

✅ Updated `ApplicationModal` component:
- Scrollable content is now restricted to `ModalProgressBar` and `ModalBody` components.
- Additionally, the scroll is shown only when `modalStep === 4`, improving UX and preventing unnecessary overflow.

🧪 Dev Notes
- Improves navigation reliability and reduces the chance of data leakage across modal instances.
- Scroll logic is now more explicit and easier to manage.

✅ Checklist
- [x] Application modal state resets correctly when leaving `is-ilani`
- [x] Scroll behavior works as expected
- [x] No regressions in modal rendering