### PR TITLE
feat: improve resume selection logic and UI flexibility

### DIFF
--- a/components/pages/jobDetail/applicationModal/modalBody/resume/ResumeItem.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/ResumeItem.tsx
@@ -9,8 +9,10 @@ import useSelectResume from "@/hooks/useSelectResume";
 
 const ResumeItem = ({
   resume: { fileName, size, uploadTime, url, cvID },
+  isDisplaySelect = true,
 }: {
   resume: CVDataFields;
+  isDisplaySelect?: boolean;
 }) => {
   const { selectedResume, placeholderUploadData } = useSelector(
     (state: RootState) => state.applicationModalData
@@ -19,10 +21,12 @@ const ResumeItem = ({
   const [setSelectedResumeData] = useSelectResume();
 
   const handleSelectResume = () => {
-    if (!isMatchResumeID || placeholderUploadData.fileName.length) {
-      setSelectedResumeData("", url, cvID);
-    } else {
-      setSelectedResumeData("Lütfen bir özgeçmiş seçin", "", "0");
+    if (isDisplaySelect) {
+      if (!isMatchResumeID || placeholderUploadData.fileName.length) {
+        setSelectedResumeData("", url, cvID, fileName, uploadTime);
+      } else {
+        setSelectedResumeData("Lütfen bir özgeçmiş seçin", "", "0");
+      }
     }
   };
 
@@ -37,20 +41,35 @@ const ResumeItem = ({
         <span className="text-white text-sm font-medium">PDF</span>
       </div>
 
-      <div className="py-3 px-2 flex items-center justify-between w-[calc(100%-44px)] hover:bg-[#f8fafd] rounded-e-[12.8px] transition-colors">
+      <div
+        className={`${
+          isDisplaySelect ? "py-3 px-2" : "ps-2"
+        } flex items-center justify-between w-[calc(100%-44px)] ${
+          isDisplaySelect ? "hover:bg-[#f8fafd]" : ""
+        } rounded-e-[12.8px] transition-colors`}
+      >
         <ResumeContent
           fileName={fileName}
           size={size}
           uploadTime={uploadTime}
         />
 
-        <div className="flex items-center gap-3 pe-1.5">
-          <DownloadButton fileName={fileName} url={url} />
+        {isDisplaySelect ? (
+          <div className="flex items-center gap-3 pe-1.5">
+            <DownloadButton fileName={fileName} url={url} isView={false} />
 
-          <span className="w-[0.5px] bg-[#E8E8E8] h-[40px] inline-block mx-1"></span>
+            <span className="w-[0.5px] bg-[#E8E8E8] h-[40px] inline-block mx-1"></span>
 
-          <RadioButton isMatchResumeID={isMatchResumeID} />
-        </div>
+            <RadioButton isMatchResumeID={isMatchResumeID} />
+          </div>
+        ) : (
+          <DownloadButton
+            fileName={fileName}
+            url={url}
+            isView={true}
+            className="h-full py-5 px-5 ms-6 border-s border-s-[#E8E8E8] hover:bg-[#F3F3F3] rounded-e-[12.8px] transition-colors duration-300"
+          />
+        )}
       </div>
     </li>
   );

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/ResumeList.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/ResumeList.tsx
@@ -38,18 +38,18 @@ const ResumeList = () => {
     const [lastResume] = resumeData;
 
     if (lastResume) {
-      const { cvID, url } = lastResume;
+      const { cvID, url, fileName, uploadTime } = lastResume;
 
       if (resume !== "0" && !resume?.length && cvID) {
-        setSelectedResumeData("", url, cvID);
+        setSelectedResumeData("", url, cvID, fileName, uploadTime);
       }
     }
   }, [resumeData, setSelectedResumeData]);
 
   useEffect(() => {
     if (findMatchUpload) {
-      const { url, cvID } = findMatchUpload;
-      setSelectedResumeData("", url, cvID);
+      const { url, cvID, fileName, uploadTime } = findMatchUpload;
+      setSelectedResumeData("", url, cvID, fileName, uploadTime);
 
       dispatch(
         setPlaceholderUploadData({ fileName: "", size: 0, uploadTime: "" })
@@ -70,13 +70,23 @@ const ResumeList = () => {
         )}
 
         {resumeData.slice(0, 2).map((resume) => (
-          <ResumeItem key={resume.cvID} resume={resume} />
+          <ResumeItem
+            key={resume.cvID}
+            resume={resume}
+            isDisplaySelect={true}
+          />
         ))}
 
         {showMoreResumes &&
           resumeData
             .slice(2, resumeData.length)
-            .map((resume) => <ResumeItem key={resume.cvID} resume={resume} />)}
+            .map((resume) => (
+              <ResumeItem
+                key={resume.cvID}
+                resume={resume}
+                isDisplaySelect={true}
+              />
+            ))}
       </ul>
 
       {resumeData.length > 2 && (

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/DownloadButton.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/DownloadButton.tsx
@@ -6,9 +6,13 @@ import { fetchData } from "@/lib/fetchData";
 const DownloadButton = ({
   url,
   fileName,
+  isView,
+  className,
 }: {
   url: string;
   fileName: string;
+  isView: boolean;
+  className?: string;
 }) => {
   const handleDownloadPdf = async (
     e: MouseEvent<HTMLButtonElement>,
@@ -24,13 +28,20 @@ const DownloadButton = ({
     <button
       onClick={(e) => handleDownloadPdf(e, url, fileName)}
       rel="noopener noreferrer"
+      className={className ?? ""}
     >
-      <HiMiniArrowDownTray
-        size={40}
-        color="#000000BF"
-        cursor="pointer"
-        className="hover:bg-[#8c8c8c1a] rounded-full p-2 transition-colors duration-300"
-      />
+      {isView ? (
+        <span className="text-[#000000BF] text-sm font-semibold">
+          Görüntüle
+        </span>
+      ) : (
+        <HiMiniArrowDownTray
+          size={40}
+          color="#000000BF"
+          cursor="pointer"
+          className="hover:bg-[#8c8c8c1a] rounded-full p-2 transition-colors duration-300"
+        />
+      )}
     </button>
   );
 };

--- a/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/ResumeContent.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/resume/resumeItem/ResumeContent.tsx
@@ -15,7 +15,7 @@ const ResumeContent = ({
         {fileName}
       </h3>
       <p className="text-[#00000099] text-xs pt-1 whitespace-nowrap text-ellipsis">
-        {size} · {uploadTime} tarihinde yüklendi
+        {size} {size ? "·" : ""} {uploadTime} tarihinde yüklendi
       </p>
     </div>
   );

--- a/hooks/useSelectResume.tsx
+++ b/hooks/useSelectResume.tsx
@@ -8,13 +8,17 @@ const useSelectResume = () => {
   const setSelectedResumeData = (
     message: string,
     resume: string,
-    cvID: string
+    cvID: string,
+    fileName: string = "",
+    uploadTime: string = ""
   ) => {
     dispatch(
       setSelectResume({
         message: message,
         resume: resume,
         selectedResume: cvID,
+        fileName: fileName,
+        uploadTime: uploadTime,
       })
     );
   };

--- a/lib/redux/features/applicationModal/modalData.ts
+++ b/lib/redux/features/applicationModal/modalData.ts
@@ -18,6 +18,8 @@ interface initialStateFields {
   uploadedFileNames: string[];
   resumeErrorMessage: string;
   selectedResume: string;
+  selectedResumeFileName: string;
+  selectedResumeUploadTime: string;
   additionalQuestionsFromJob: {
     isSelectAnswer: boolean;
     isTextAnswer: boolean;
@@ -43,6 +45,8 @@ const initialState: initialStateFields = {
   uploadedFileNames: [],
   resumeErrorMessage: "",
   selectedResume: "",
+  selectedResumeFileName: "",
+  selectedResumeUploadTime: "",
 
   additionalQuestionsFromJob: {
     isSelectAnswer: false,
@@ -103,11 +107,15 @@ export const applicationModalDataSlice = createSlice({
         selectedResume: string;
         message: string;
         resume: string;
+        fileName: string;
+        uploadTime: string;
       }>
     ) => {
       state.selectedResume = action.payload.selectedResume;
       state.resumeErrorMessage = action.payload.message;
       state.applicationData.resume = action.payload.resume;
+      state.selectedResumeFileName = action.payload.fileName;
+      state.selectedResumeUploadTime = action.payload.uploadTime;
     },
 
     setAdditionalQuestionsFromJob: (state, action) => {


### PR DESCRIPTION
## 📝 Description

This PR enhances the resume selection experience by improving UI component flexibility and updating related modal state logic.

---

## 🔧 What's Changed  

- **ResumeItem component**
  - Added `isDisplaySelect` prop to control the visibility of the select radio button.

- **DownloadButton component**
  - Added `isView` and `className` props for more flexible reuse across different views.

- **Modal data slice**
  - Extended `setSelectResume` reducer to handle new fields: `selectedResumeFileName` and `selectedResumeUploadTime`.

- **useSelectResume hook**
  - Updated to set both `fileName` and `uploadTime` when selecting a resume.

- **ResumeList component**
  - Integrated `setSelectedResumeData` with the new modal state fields.
  - Passed `isDisplaySelect`, `fileName`, and `uploadTime` props to ResumeItem.

- **ResumeContent component**
  - Conditionally renders the "·" separator only if file size data is available.

---

## ✅ Benefits

- Improved control over resume selection UI.
- More explicit and maintainable modal state management.
- Enhanced reusability of UI components like `DownloadButton`.