### PR TITLE
feat: enable editable mode on company card component

### DIFF
--- a/components/pages/jobDetail/applicationModal/modalBody/ApplicationSummary.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/ApplicationSummary.tsx
@@ -29,7 +29,7 @@ const ApplicationSummary = () => {
 
       {additionalQuestionsFromJob.isSelectAnswer &&
         additionalQuestionsFromJob.isTextAnswer && (
-          <SummaryContent contentTitle="Ek Sorular">
+          <SummaryContent contentTitle="Ek Sorular" step={3}>
             <SummaryQuestions />
           </SummaryContent>
         )}

--- a/components/pages/jobDetail/applicationModal/modalBody/applicationSummary/SummaryContent.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/applicationSummary/SummaryContent.tsx
@@ -1,14 +1,32 @@
-import React, { ReactElement } from "react";
+import {
+  setIsEdit,
+  setModalStep,
+} from "@/lib/redux/features/applicationModal/progressBar";
+import { AppDispatch } from "@/lib/redux/store";
+import React, { ReactElement, useCallback } from "react";
+import { useDispatch } from "react-redux";
 
 const SummaryContent = ({
   contentTitle,
   subTitle,
   children,
+  step,
 }: {
   contentTitle: string;
   subTitle?: string;
   children: ReactElement;
+  step: number;
 }) => {
+  const dispatch = useDispatch<AppDispatch>();
+
+  const handleApplicationMenu = useCallback(
+    (step: number) => {
+      dispatch(setModalStep(step));
+      dispatch(setIsEdit(true));
+    },
+    [dispatch]
+  );
+
   return (
     <div className="px-6">
       <div className="flex items-start justify-between mb-3">
@@ -16,7 +34,10 @@ const SummaryContent = ({
           <h4 className="text-[#000000E6] font-semibold">{contentTitle}</h4>
           <p className="mt-3 text-[#00000099] text-xs">{subTitle}</p>
         </div>
-        <button className="text-[#4045ef] hover:underline text-sm font-semibold">
+        <button
+          className="text-[#4045ef] hover:underline text-sm font-semibold"
+          onClick={() => handleApplicationMenu(step)}
+        >
           Düzenle
         </button>
       </div>

--- a/components/pages/jobDetail/applicationModal/modalBody/applicationSummary/contactInformation/ContactInformation.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/applicationSummary/contactInformation/ContactInformation.tsx
@@ -10,7 +10,7 @@ const ContactInformation = () => {
   );
 
   return (
-    <SummaryContent contentTitle="İletişim bilgileri">
+    <SummaryContent contentTitle="İletişim bilgileri" step={1}>
       <ContactItem
         items={[
           {

--- a/components/pages/jobDetail/applicationModal/modalBody/applicationSummary/summaryResume/SummaryResume.tsx
+++ b/components/pages/jobDetail/applicationModal/modalBody/applicationSummary/summaryResume/SummaryResume.tsx
@@ -12,6 +12,7 @@ const SummaryResume = () => {
     <SummaryContent
       contentTitle="Özgeçmiş"
       subTitle="Başvurunuzun değerlendirilebilmesi için güncel bir CV ekleyin*"
+      step={2}
     >
       <div className="w-[342px] max-sm:w-auto mt-4">
         <ResumeItem

--- a/components/pages/jobDetail/applicationModal/modalControls/ModalControls.tsx
+++ b/components/pages/jobDetail/applicationModal/modalControls/ModalControls.tsx
@@ -1,6 +1,7 @@
 import CustomButton from "@/components/ui/CustomButton";
 import { setResumeErrorMessage } from "@/lib/redux/features/applicationModal/modalData";
 import {
+  setIsEdit,
   setModalStep,
   setProgressBarValue,
 } from "@/lib/redux/features/applicationModal/progressBar";
@@ -21,10 +22,12 @@ const ModalControls = ({
   };
 }) => {
   const dispatch = useDispatch<AppDispatch>();
-  const { progressBar, modalStep, isAdditionalQuestions } = useSelector(
+  const { progressBar, modalStep, isAdditionalQuestions, isEdit } = useSelector(
     (state: RootState) => state.applicationModalProgressBar
   );
   const { barWidth, barWidthValue } = progressBar;
+  const isFormValid =
+    !isErrors.length && !Object.values(formValues as object).includes("");
 
   const prevStep = () => {
     dispatch(setResumeErrorMessage(""));
@@ -50,11 +53,17 @@ const ModalControls = ({
   const nextStep = () => {
     dispatch(setResumeErrorMessage(""));
 
+    if (isEdit && isFormValid) {
+      dispatch(setIsEdit(false));
+      dispatch(setModalStep(4));
+      return;
+    }
+
     if (!extraControl?.state) {
       return dispatch(setResumeErrorMessage(extraControl?.message as string));
     }
 
-    if (!isErrors.length && !Object.values(formValues as object).includes("")) {
+    if (isFormValid) {
       if (modalStep < 4) {
         dispatch(setModalStep(modalStep + 1));
       }
@@ -76,7 +85,7 @@ const ModalControls = ({
 
   return (
     <div className="py-4 px-6 flex justify-end gap-2">
-      {modalStep > 1 && (
+      {modalStep > 1 && !isEdit && (
         <CustomButton
           text="Geri"
           className="hover:!bg-[#EBF4FD] !bg-transparent !text-[#4045ef] font-semibold !py-1.5 !px-2 !rounded-sm"
@@ -88,7 +97,9 @@ const ModalControls = ({
       {modalStep !== 4 ? (
         <CustomButton
           text={
-            (modalStep === 2 && !isAdditionalQuestions) || modalStep === 3
+            (modalStep === 2 && !isAdditionalQuestions) ||
+            modalStep === 3 ||
+            isEdit
               ? "İncele"
               : "İleri"
           }

--- a/components/pages/jobDetail/applicationModal/modalControls/ModalProgressBar.tsx
+++ b/components/pages/jobDetail/applicationModal/modalControls/ModalProgressBar.tsx
@@ -5,6 +5,7 @@ import { useSelector } from "react-redux";
 const ModalProgressBar = () => {
   const {
     progressBar: { barWidthValue },
+    isEdit,
   } = useSelector((state: RootState) => state.applicationModalProgressBar);
 
   return (
@@ -14,14 +15,16 @@ const ModalProgressBar = () => {
           <div
             className={`h-full bg-[#4045ef] rounded-s-full transition-all duration-300`}
             style={{
-              width: `${barWidthValue.toFixed(2)}%`,
+              width: isEdit ? "100%" : `${barWidthValue.toFixed(2)}%`,
             }}
           ></div>
         </div>
 
         <span className="text-sm text-[#00000099] flex-[5%] text-end">
           %
-          {barWidthValue?.toFixed(0).includes("-")
+          {isEdit
+            ? "100"
+            : barWidthValue?.toFixed(0).includes("-")
             ? "0"
             : barWidthValue?.toFixed(0)}
         </span>

--- a/lib/redux/features/applicationModal/progressBar.ts
+++ b/lib/redux/features/applicationModal/progressBar.ts
@@ -7,6 +7,7 @@ interface ProgressBarState {
     barWidth: number;
     barWidthValue: number;
   };
+  isEdit: boolean;
 }
 
 const initialState: ProgressBarState = {
@@ -16,6 +17,7 @@ const initialState: ProgressBarState = {
     barWidth: 0,
     barWidthValue: 0,
   },
+  isEdit: false,
 };
 
 export const ProgressBarSlice = createSlice({
@@ -43,6 +45,10 @@ export const ProgressBarSlice = createSlice({
     resetProgressBarValue: () => {
       return initialState;
     },
+
+    setIsEdit: (state, action: PayloadAction<boolean>) => {
+      state.isEdit = action.payload;
+    },
   },
 });
 
@@ -51,4 +57,5 @@ export const {
   setModalStep,
   setIsAdditionalQuestions,
   resetProgressBarValue,
+  setIsEdit,
 } = ProgressBarSlice.actions;


### PR DESCRIPTION
## Description

This PR introduces an edit mode that allows users to return and make changes on the application review screen.

---

### 🛠️ What's Added

- **`SummaryContent`**
  - Added `step` prop to control current application step.
  - Added `handleApplicationMenu` callback to enable back navigation.

- **Component Integration**
  - `ApplicationSummary`, `ContactInformation`, and `SummaryResume` now support the new `step` prop via `SummaryContent`.

- **Global State (Redux)**
  - Extended `progressBarSlice`:
    - Added `isEdit` state.
    - Added `setIsEdit` reducer to toggle edit mode.

- **`ModalProgressBar`**
  - Displays 100% progress when `isEdit` is `true`, indicating full review access.

- **`ModalControls`**
  - Button text and `nextStep` behavior now respond conditionally to `isEdit` state.

---

### 📌 Notes

> This feature improves UX by giving users the flexibility to review and revise their application before final submission.

---

### ✅ Checklist

- [x] Edit mode toggle via Redux state
- [x] Step-aware component rendering
- [x] Conditional rendering in controls and progress bar
- [x] Clean and scalable architecture

---

### 🖼️ Screenshots
<details>

<br/>
<summary>Click to expand</summary>
<strong>1. Edit Button Click (Trigger)</strong> 
<img width="1015" height="754" alt="Ekran görüntüsü 2025-07-30 165134" src="https://github.com/user-attachments/assets/8a5def34-d7f2-4c3f-9d14-897868056e4f" />

<strong>2. Editable Mode Opened</strong> 
<img width="997" height="782" alt="Ekran görüntüsü 2025-07-30 165346" src="https://github.com/user-attachments/assets/0e99b2b7-c862-4682-9ea9-22953fc9a8dc" />
</details>