### PR TITLE
feat(job-intro): add total application count display with conditional messaging

### DIFF
--- a/app/api/firebase/applications/get-application/route.ts
+++ b/app/api/firebase/applications/get-application/route.ts
@@ -1,4 +1,11 @@
-import { collection, getDocs, limit, query, where } from "firebase/firestore";
+import {
+  collection,
+  getCountFromServer,
+  getDocs,
+  limit,
+  query,
+  where,
+} from "firebase/firestore";
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "../../firebaseConfig";
 import { ApplicationData } from "@/types/jobApplication";
@@ -9,18 +16,41 @@ export async function GET(req: NextRequest) {
   const postId = searchParams.get("postId");
 
   try {
-    const q = query(
+    //* Get user applied data *//
+    const appliedQuery = query(
       collection(db, "applications"),
       where("cid", "==", candidateId),
       where("postId", "==", postId),
       limit(1)
     );
-    const querySnapshot = await getDocs(q);
 
+    const querySnapshot = await getDocs(appliedQuery);
     const firstDoc = querySnapshot?.docs[0];
     const objectData = firstDoc?.data() as ApplicationData;
 
-    return NextResponse.json({ appliedData: objectData }, { status: 200 });
+    //* Get current job total applied count *//
+    const totalAppliedQuery = query(
+      collection(db, "applications"),
+      where("postId", "==", postId)
+    );
+    const jobTotalAppliedCount: number = (
+      await getCountFromServer(totalAppliedQuery)
+    ).data().count;
+
+    let totalAppliedText;
+
+    if (jobTotalAppliedCount === 0) {
+      totalAppliedText = "Henüz başvuru yok";
+    } else if (jobTotalAppliedCount > 100) {
+      totalAppliedText = "100'ün üzerinde başvuru";
+    } else {
+      totalAppliedText = `${jobTotalAppliedCount} kişi başvurdu`;
+    }
+
+    return NextResponse.json(
+      { appliedData: objectData, totalAppliedText },
+      { status: 200 }
+    );
   } catch (error) {
     if (error instanceof Error) {
       return NextResponse.json({ message: error.message }, { status: 500 });

--- a/components/pages/jobDetail/jobIntro/JobIntro.tsx
+++ b/components/pages/jobDetail/jobIntro/JobIntro.tsx
@@ -9,10 +9,11 @@ import IntroLink from "./IntroLink";
 import { JobIntroInterface } from "@/types/jobDetail";
 import LoaderSkeleton from "@/components/ui/LoaderSkeleton";
 import { Typography } from "@mui/material";
-import dayjs from "dayjs";
 import { useGetApplicationQuery } from "@/lib/redux/services/jobApplicationApi";
 import { AuthContext } from "@/context/authContext";
 import dynamic from "next/dynamic";
+import { formatApplyTime } from "@/lib/utils/formatApplyTime";
+import styles from "./info-dot.module.scss";
 
 //* IntroRight component lazy load *//
 const IntroRight = dynamic(() => import("./IntroSectionRight/IntroRight"), {
@@ -112,7 +113,9 @@ const JobIntro = (props: JobIntroInterface) => {
               </Typography>
             )}
 
-            <div className="flex flex-wrap max-lg:justify-center gap-x-[25px] gap-y-[8px] mt-[5px]">
+            <div
+              className={`flex items-center flex-wrap max-lg:justify-center gap-x-4 gap-y-[8px] mt-[5px] ${styles.infoDot}`}
+            >
               <IntroLink
                 JobLocationFilterStatus={{
                   isApplyJob: true,
@@ -165,11 +168,33 @@ const JobIntro = (props: JobIntroInterface) => {
                 <div className="flex gap-[5px]">
                   <BsClock size={20} color="696969" />
                   <time className="text-sm text-[#696969]">
-                    {dayjs(
+                    {formatApplyTime(
                       datePosted?.seconds * 1000 +
                         datePosted?.nanoseconds / 1000000
-                    ).format("DD.MM.YYYY")}
+                    )}
                   </time>
+                </div>
+              )}
+
+              {isLoading ? (
+                <Typography variant="subtitle1">
+                  <LoaderSkeleton
+                    testID="time-skeleton"
+                    animationType="wave"
+                    length={1}
+                    variant="text"
+                    sxClass={{
+                      borderRadius: "4px",
+                      width: "100px",
+                      height: "25px",
+                    }}
+                  />
+                </Typography>
+              ) : (
+                <div>
+                  <span className="text-sm text-[#696969]">
+                    {data?.totalAppliedText}
+                  </span>
                 </div>
               )}
             </div>

--- a/components/pages/jobDetail/jobIntro/PostApplication/SubmittedResume.tsx
+++ b/components/pages/jobDetail/jobIntro/PostApplication/SubmittedResume.tsx
@@ -19,7 +19,7 @@ const SubmittedResume = ({
       isViewContent={
         <>
           <FaRegFileAlt size={16} strokeWidth={5} />
-          <span>Gönderilen özgeçmiş</span>
+          <span className="whitespace-nowrap">Gönderilen özgeçmiş</span>
         </>
       }
     />

--- a/components/pages/jobDetail/jobIntro/info-dot.module.scss
+++ b/components/pages/jobDetail/jobIntro/info-dot.module.scss
@@ -1,0 +1,15 @@
+.infoDot {
+  div {
+    position: relative;
+
+    &:not(:last-child)::before {
+      content: "·";
+      position: absolute;
+      top: 50%;
+      left: calc(100% + 6px);
+      transform: translateY(-50%);
+      color: #00000099;
+      font-size: 14px;
+    }
+  }
+}

--- a/lib/redux/services/jobApplicationApi.ts
+++ b/lib/redux/services/jobApplicationApi.ts
@@ -19,7 +19,7 @@ export const jobApplicationApi = createApi({
       ],
     }),
     getApplication: builder.query<
-      { appliedData: ApplicationData },
+      { appliedData: ApplicationData; totalAppliedText: string },
       { candidateId: string; postId: string }
     >({
       query: ({ candidateId, postId }) => ({

--- a/lib/utils/formatApplyTime.tsx
+++ b/lib/utils/formatApplyTime.tsx
@@ -5,4 +5,5 @@ import "dayjs/locale/tr";
 dayjs.extend(relativeTime);
 dayjs.locale("tr");
 
-export const formatApplyTime = (time: string): string => dayjs(time).fromNow();
+export const formatApplyTime = (time: string | number): string =>
+  dayjs(time).fromNow();


### PR DESCRIPTION
### What was done
- Fetched the total application count in the get-application API route  
- Created conditional text to describe the number of applications (e.g., "Henüz başvuru yok", "100'ün üzerinde başvuru", or "X kişi başvurdu")  
- Sent the prepared text to the frontend for direct display  
- Updated the JobIntro component to show the totalAppliedText  
- Extended the formatApplyTime utility to accept a number as a parameter  
- Added info-dot.module.scss for spacing dot styling and integrated it into the JobIntro component  

### Why
This improves user experience by providing clear, human-readable application count messages directly from the backend, reducing frontend logic and centralizing business rules.

### Notes
- The API now returns user-friendly application count text, simplifying frontend responsibilities  
- Styling improvements ensure consistent spacing and UI alignment in the JobIntro component  
