### PR TITLE
feat(exit-modal): implement exit modal for is-ilani route

### DIFF
--- a/app/is-ilani/page.tsx
+++ b/app/is-ilani/page.tsx
@@ -22,14 +22,17 @@ const ApplicationStatusModal = dynamic(
     import(
       "@/components/pages/jobDetail/applicationModal/ApplicationStatusModal"
     ),
-  {
-    ssr: false,
-  }
+  { ssr: false }
 );
 
 const ApplicationModal = dynamic(
   () =>
     import("@/components/pages/jobDetail/applicationModal/ApplicationModal"),
+  { ssr: false }
+);
+
+const ExitModal = dynamic(
+  () => import("@/components/pages/jobDetail/applicationModal/ExitModal"),
   { ssr: false }
 );
 
@@ -39,7 +42,7 @@ const JobDetail = () => {
     postID: atob(params.get("jpi") ?? ""),
     companyID: atob(params.get("jci") ?? ""),
   });
-  const { openApplicationModal } = useSelector(
+  const { openApplicationModal, isExitModal } = useSelector(
     (state: RootState) => state.touch
   );
   const { status, postId } = useSelector(
@@ -118,6 +121,8 @@ const JobDetail = () => {
           }
         />
       )}
+
+      {isExitModal && <ExitModal />}
 
       {(status !== "" || data?.job.postId === postId) && (
         <ApplicationStatusModal />

--- a/components/pages/jobDetail/applicationModal/ApplicationModal.tsx
+++ b/components/pages/jobDetail/applicationModal/ApplicationModal.tsx
@@ -8,7 +8,7 @@ import {
   setIsAdditionalQuestions,
   setProgressBarValue,
 } from "@/lib/redux/features/applicationModal/progressBar";
-import { setApplicationModal } from "@/lib/redux/features/touch";
+import { setExitModalState } from "@/lib/redux/features/touch";
 import { JobPostingAdditionalQuestions } from "@/types/auth/employer/open-jobs.types";
 
 const ApplicationModal = ({
@@ -25,10 +25,7 @@ const ApplicationModal = ({
     (state: RootState) => state.applicationModalProgressBar.modalStep
   );
 
-  const handleCloseModal = () => {
-    dispatch(setApplicationModal(false));
-    document.body.style.overflow = "visible";
-  };
+  const handleCloseModal = () => dispatch(setExitModalState(true));
 
   useEffect(() => {
     dispatch(
@@ -53,7 +50,7 @@ const ApplicationModal = ({
         <ModalProgressBar />
 
         <div
-          className={`${modalStep === 1 ? "h-max" : ""}${
+          className={`${modalStep === 1 ? "h-max" : ""} ${
             modalStep === 4 ? "h-[500px] overflow-auto" : ""
           } h-full`}
         >

--- a/components/pages/jobDetail/applicationModal/ExitModal.tsx
+++ b/components/pages/jobDetail/applicationModal/ExitModal.tsx
@@ -1,0 +1,118 @@
+import CustomButton from "@/components/ui/CustomButton";
+import { resetApplicationData } from "@/lib/redux/features/applicationModal/modalData";
+import { resetProgressBarValue } from "@/lib/redux/features/applicationModal/progressBar";
+import {
+  changeShowMoreResumes,
+  setApplicationModal,
+  setExitModalState,
+} from "@/lib/redux/features/touch";
+import { AppDispatch } from "@/lib/redux/store";
+import React, { useEffect, useState } from "react";
+import { IoCloseOutline } from "react-icons/io5";
+import { useDispatch } from "react-redux";
+
+const ExitModal = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const [isSmallBreakpoint, setIsSmallBreakpoint] = useState<boolean>(false);
+
+  const handleCloseExitModal = () => dispatch(setExitModalState(false));
+
+  const handleExitApplication = () => {
+    dispatch(setExitModalState(false));
+    dispatch(setApplicationModal(false));
+    dispatch(resetApplicationData());
+    dispatch(resetProgressBarValue());
+    dispatch(changeShowMoreResumes());
+  };
+
+  useEffect(() => {
+    const onSmall = () => {
+      if (window.innerWidth < 640) {
+        setIsSmallBreakpoint(true);
+      } else {
+        setIsSmallBreakpoint(false);
+      }
+    };
+
+    onSmall();
+    window.addEventListener("resize", onSmall);
+
+    return () => {
+      window.removeEventListener("resize", onSmall);
+      onSmall();
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") dispatch(setExitModalState(false));
+    };
+
+    window.addEventListener("keydown", handleEsc);
+    return () => window.removeEventListener("keydown", handleEsc);
+  }, [dispatch]);
+
+  return (
+    <div
+      className="fixed top-0 left-0 w-full h-full bg-black/55 z-50"
+      onClick={handleCloseExitModal}
+    >
+      <div
+        className="bg-white fixed left-1/2 sm:top-[178.32px] max-sm:top-1/2 max-sm:-translate-y-1/2 -translate-x-1/2 rounded-lg max-sm:w-[90%] max-[800px]:w-[70%]"
+        role="dialog"
+        aria-modal={true}
+        aria-labelledby="application-exit-modal-title"
+        aria-describedby="application-exit-modal-description"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-between max-sm:justify-center p-4 max-sm:px-3 sm:border-b sm:border-gray-200">
+          <h2
+            className="text-lg text-[#000000E6] font-medium max-[375px]:text-[16px] max-[320px]:text-center"
+            id="application-exit-modal-title"
+          >
+            Başvurudan çıkmak istiyor musunuz?
+          </h2>
+
+          {!isSmallBreakpoint && (
+            <button onClick={handleCloseExitModal}>
+              <IoCloseOutline size={32} />
+            </button>
+          )}
+        </div>
+
+        <div className="p-4 max-sm:pt-0">
+          <p
+            className="max-sm:text-center"
+            id="application-exit-modal-description"
+          >
+            Başvurudan çıkarsanız, yüklenen dosyalarınız saklanır;{" "}
+            <br className="max-[800px]:hidden" /> ancak ek sorulara verdiğiniz
+            yanıtlar ve iletişim bilgileri kaybolur.
+          </p>
+        </div>
+
+        <div className="text-end border-t max-sm:flex max-sm:justify-between border-gray-200 py-3 max-sm:py-0 sm:px-4">
+          <CustomButton
+            text="Başvurudan Çık"
+            className="sm:!py-1.5 px-4 max-sm!:py-4 flex-1/2 whitespace-nowrap max-sm:!bg-transparent max-sm:!text-[#000000E6] max-sm:font-medium max-sm:text-lg max-sm:!rounded-none"
+            handleClick={handleExitApplication}
+          />
+
+          {isSmallBreakpoint && (
+            <span className="border border-gray-200"></span>
+          )}
+
+          {isSmallBreakpoint && (
+            <CustomButton
+              text="Devam Et"
+              className="sm:!py-1.5 px-4 !rounded-none max-sm!:py-4 max-sm:!bg-transparent flex-1/2 whitespace-nowrap max-sm:!text-[#000000E6] max-sm:font-medium max-sm:text-lg"
+              handleClick={() => dispatch(setExitModalState(false))}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExitModal;

--- a/components/pages/jobDetail/applicationModal/modalUI/ModalHeader.tsx
+++ b/components/pages/jobDetail/applicationModal/modalUI/ModalHeader.tsx
@@ -1,5 +1,4 @@
-import { resetProgressBarValue } from "@/lib/redux/features/applicationModal/progressBar";
-import { setApplicationModal } from "@/lib/redux/features/touch";
+import { setExitModalState } from "@/lib/redux/features/touch";
 import { AppDispatch, RootState } from "@/lib/redux/store";
 import React from "react";
 import { IoCloseOutline } from "react-icons/io5";
@@ -17,11 +16,7 @@ const ModalHeader = ({
     (state: RootState) => state.applyModalScreen
   );
 
-  const handleCloseModal = () => {
-    dispatch(setApplicationModal(false));
-    dispatch(resetProgressBarValue());
-    document.body.style.overflow = "visible";
-  };
+  const handleCloseModal = () => dispatch(setExitModalState(true));
 
   return (
     <div className="flex justify-between items-center max-md:items-start max-md:gap-x-3 py-4 px-6 max-sm:px-3 border-b border-gray-200">

--- a/lib/redux/features/touch.ts
+++ b/lib/redux/features/touch.ts
@@ -6,6 +6,7 @@ const initialState: initialState = {
   openCustomList: "",
   openApplicationModal: false,
   showMoreResumes: false,
+  isExitModal: false,
 };
 
 interface initialState {
@@ -14,6 +15,7 @@ interface initialState {
   openCustomList: string;
   openApplicationModal: boolean;
   showMoreResumes: boolean;
+  isExitModal: boolean;
 }
 
 export const touch = createSlice({
@@ -42,6 +44,10 @@ export const touch = createSlice({
     changeShowMoreResumes: (state) => {
       state.showMoreResumes = !state.showMoreResumes;
     },
+
+    setExitModalState: (state, action: PayloadAction<boolean>) => {
+      state.isExitModal = action.payload;
+    },
   },
 });
 
@@ -51,4 +57,5 @@ export const {
   setOpenCustomList,
   setApplicationModal,
   changeShowMoreResumes,
+  setExitModalState,
 } = touch.actions;


### PR DESCRIPTION
### Summary
This PR introduces an exit modal for the `is-ilani` route, providing users with a confirmation step before exiting the application process.

### Changes
- Added `ExitModal` component with responsive design and accessibility attributes (`role="dialog"`, `aria-modal`, `aria-labelledby`)
- Integrated `isExitModal` state and `setExitModalState` reducer into the `touch` slice
- Updated `ModalHeader` and `ApplicationModal` to:
  - Dispatch modal open/close actions
  - Manage body scroll lock when modal is active

### Why
To prevent accidental loss of application progress and improve user experience with a clear confirmation flow.

### Notes
- Handles both small and large breakpoints for optimal display
- Body scroll lock ensures background content is not scrollable when modal is open
- Accessibility improvements make the modal screen reader-friendly