### PR TITLE
feat(job-overview): implement JobOverview sidebar with improved UI

### DIFF
--- a/app/is-ilani/page.tsx
+++ b/app/is-ilani/page.tsx
@@ -17,6 +17,7 @@ import { setApplicationModal } from "@/lib/redux/features/touch";
 import { setJobDetail } from "@/lib/redux/features/jobDetail";
 import dynamic from "next/dynamic";
 import JobAbout from "@/components/pages/jobDetail/JobAbout/JobAbout";
+import LoaderSkeleton from "@/components/ui/LoaderSkeleton";
 
 const ApplicationStatusModal = dynamic(
   () =>
@@ -34,6 +35,11 @@ const ApplicationModal = dynamic(
 
 const ExitModal = dynamic(
   () => import("@/components/pages/jobDetail/ExitModal/ExitModal"),
+  { ssr: false }
+);
+
+const JobOverview = dynamic(
+  () => import("@/components/pages/jobDetail/JobAbout/JobSidebar/JobOverview"),
   { ssr: false }
 );
 
@@ -129,13 +135,37 @@ const JobDetail = () => {
         <ApplicationStatusModal />
       )}
 
-      <JobAbout
-        about={{
-          description: data?.job.jobAbout as string,
-          requirements: data?.job.requirements as string[],
-          responsibilities: data?.job.responsibilities as string[],
-        }}
-      />
+      <div className="container flex max-lg:flex-col gap-[25px] justify-between py-[50px]">
+        <JobAbout
+          about={{
+            description: data?.job.jobAbout as string,
+            requirements: data?.job.requirements as string[],
+            responsibilities: data?.job.responsibilities as string[],
+          }}
+        />
+
+        {data?.job ? (
+          <JobOverview
+            overviewData={{
+              postedDate: data?.job.datePosted as Timestamp,
+              applicationDeadline: data?.job.applicationDeadlineDate as string,
+              careerLevel: data?.job.positionLevel as string,
+              educationLevel: data?.job.educationLevel as string[],
+              experience: data?.job.experienceTime as string,
+              location: data?.job.location as string,
+              gender: data.job.gender as string,
+              salary: data.job.salary as string,
+            }}
+          />
+        ) : (
+          <LoaderSkeleton
+            length={1}
+            variant="rounded"
+            animationType="pulse"
+            className="lg:!h-[613px] flex-[32.3%] max-lg:flex-none max-lg:!h-[728px] !rounded-lg"
+          />
+        )}
+      </div>
     </main>
   );
 };

--- a/components/pages/jobDetail/JobAbout/JobAbout.tsx
+++ b/components/pages/jobDetail/JobAbout/JobAbout.tsx
@@ -54,8 +54,8 @@ const JobAbout = ({ about }: JobAbout) => {
   }, []);
 
   return (
-    <div className="py-[50px] max-[992px]:py-[25px]">
-      <article className="container">
+    <div className="flex-[66.7%] max-lg:flex-none">
+      <article>
         {description ? (
           <JobDescription description={description} />
         ) : (
@@ -68,7 +68,7 @@ const JobAbout = ({ about }: JobAbout) => {
 
             <TailwindSkeleton
               length={4}
-              dynamicWidths={["100%", "75%", "83.3333", "50%"]}
+              dynamicWidths={["85%", "80%", "75%", "70%"]}
               className="flex flex-col gap-3"
               animationClass="bg-[#E3E3E3] h-[10px] rounded-full"
             />
@@ -114,7 +114,7 @@ const JobAbout = ({ about }: JobAbout) => {
         )}
       </article>
 
-      <div className="container">
+      <div>
         {!isMobile ? (
           jobTitle && <ShareDesktop jobTitle={jobTitle} />
         ) : (

--- a/components/pages/jobDetail/JobAbout/JobSidebar/JobOverview.tsx
+++ b/components/pages/jobDetail/JobAbout/JobSidebar/JobOverview.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import List from "./List";
+import { ICONS } from "./icons";
+import dayjs from "dayjs";
+import "dayjs/locale/tr";
+import { OverviewData } from "./sidebar.types";
+dayjs.locale("tr");
+
+const JobOverview = ({ overviewData }: { overviewData: OverviewData }) => {
+  const {
+    postedDate,
+    applicationDeadline,
+    careerLevel,
+    educationLevel,
+    experience,
+    location,
+    gender,
+    salary,
+  } = overviewData;
+
+  const timestamp =
+    postedDate?.seconds * 1000 + Math.floor(postedDate?.nanoseconds / 1000000);
+
+  return (
+    <aside className="bg-[#f5f7fc] p-[30px] rounded-lg flex-[32.3%] h-max max-lg:flex-none">
+      <h2 className="text-lg text-[#202124] font-medium mb-[18px]">İş Özeti</h2>
+
+      <List
+        listItems={[
+          {
+            icon: ICONS.calendar,
+            id: 1,
+            text: "Yayınlanma tarihi",
+            value: postedDate && dayjs(timestamp).format("DD MMMM YYYY"),
+          },
+
+          {
+            icon: ICONS.location,
+            id: 2,
+            text: "Konum",
+            value: location,
+          },
+
+          {
+            icon: ICONS.money,
+            id: 3,
+            text: "Maaş",
+            value: salary ?? "Belirtilmemiş",
+          },
+
+          {
+            icon: ICONS.time,
+            id: 4,
+            text: "Son başvuru tarihi",
+            value: dayjs(applicationDeadline).format("DD MMMM YYYY"),
+          },
+
+          {
+            icon: ICONS.experience,
+            id: 5,
+            text: "Deneyim",
+            value: experience,
+          },
+
+          {
+            icon: ICONS.gender,
+            id: 6,
+            text: "Cinsiyet",
+            value: gender ?? "Belirtilmemiş",
+          },
+
+          {
+            icon: ICONS.qualification,
+            id: 7,
+            text: "Eğitim düzeyi",
+            value: educationLevel?.join(" / "),
+          },
+
+          {
+            icon: ICONS.level,
+            id: 8,
+            text: "Kariyer seviyesi",
+            value: careerLevel,
+          },
+        ]}
+      />
+    </aside>
+  );
+};
+
+export default JobOverview;

--- a/components/pages/jobDetail/JobAbout/JobSidebar/List.tsx
+++ b/components/pages/jobDetail/JobAbout/JobSidebar/List.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import ListItem from "./ListItem";
+import { OverviewList } from "./sidebar.types";
+
+const List = ({ listItems }: { listItems: OverviewList[] }) => {
+  return (
+    <ul className="flex flex-col gap-[15px]">
+      {listItems.map((item) => (
+        <ListItem key={item.id} list={item} />
+      ))}
+    </ul>
+  );
+};
+
+export default List;

--- a/components/pages/jobDetail/JobAbout/JobSidebar/ListItem.tsx
+++ b/components/pages/jobDetail/JobAbout/JobSidebar/ListItem.tsx
@@ -1,0 +1,23 @@
+import React, { memo } from "react";
+import { OverviewList } from "./sidebar.types";
+
+const ListItem = ({ list }: { list: OverviewList }) => {
+  const { icon: Icon, text, value } = list;
+
+  return (
+    <li className="flex gap-[15px]">
+      <div className="text-[#1967d2] text-[28px]">
+        <Icon />
+      </div>
+
+      <div>
+        <span className="text-[#202124] font-medium">{text}</span>
+        <span className="text-[#77838f] text-[15px] block leading-[26.25px]">
+          {value}
+        </span>
+      </div>
+    </li>
+  );
+};
+
+export default memo(ListItem);

--- a/components/pages/jobDetail/JobAbout/JobSidebar/icons.ts
+++ b/components/pages/jobDetail/JobAbout/JobSidebar/icons.ts
@@ -1,0 +1,19 @@
+import { CiCalendarDate } from "react-icons/ci";
+import { IoLocationOutline } from "react-icons/io5";
+import { PiMoneyWavyLight } from "react-icons/pi";
+import { CgSandClock } from "react-icons/cg";
+import { RiUserStarLine } from "react-icons/ri";
+import { TbUsers } from "react-icons/tb";
+import { LiaSchoolSolid } from "react-icons/lia";
+import { GiLevelEndFlag } from "react-icons/gi";
+
+export const ICONS = {
+  calendar: CiCalendarDate,
+  location: IoLocationOutline,
+  money: PiMoneyWavyLight,
+  time: CgSandClock,
+  experience: RiUserStarLine,
+  gender: TbUsers,
+  qualification: LiaSchoolSolid,
+  level: GiLevelEndFlag,
+};

--- a/components/pages/jobDetail/JobAbout/JobSidebar/sidebar.types.ts
+++ b/components/pages/jobDetail/JobAbout/JobSidebar/sidebar.types.ts
@@ -1,0 +1,20 @@
+import { Timestamp } from "firebase/firestore";
+import { IconType } from "react-icons/lib";
+
+export type OverviewList = {
+  id: number;
+  icon: IconType;
+  text: string;
+  value: string;
+};
+
+export interface OverviewData {
+  postedDate: Timestamp;
+  location: string;
+  salary?: string;
+  applicationDeadline: string;
+  experience: string;
+  gender?: string;
+  educationLevel: string[];
+  careerLevel: string;
+}

--- a/components/pages/jobDetail/JobAbout/SharePost/DesktopShareLinks.tsx
+++ b/components/pages/jobDetail/JobAbout/SharePost/DesktopShareLinks.tsx
@@ -38,7 +38,7 @@ const DesktopShareLinks = ({
             href={url}
             target="_blank"
             rel="noopener noreferrer"
-            className={`flex items-center px-7 py-2 rounded-lg text-sm text-white gap-x-2 ${
+            className={`flex items-center px-7 py-2 rounded-lg text-sm text-white gap-x-2 whitespace-nowrap w-[134.65px] ${
               className ?? ""
             }`}
           >

--- a/components/pages/jobDetail/JobAbout/SharePost/ShareDesktop.tsx
+++ b/components/pages/jobDetail/JobAbout/SharePost/ShareDesktop.tsx
@@ -16,7 +16,9 @@ const ShareDesktop = ({ jobTitle }: { jobTitle: string }) => {
 
   return (
     <div className="flex items-center">
-      <h2 className="text-[#202124] font-medium me-2.5">Bu ilanı paylaş</h2>
+      <h2 className="text-[#202124] font-medium me-2.5 whitespace-nowrap">
+        Bu ilanı paylaş
+      </h2>
 
       <DesktopShareLinks
         links={[
@@ -38,7 +40,7 @@ const ShareDesktop = ({ jobTitle }: { jobTitle: string }) => {
 
           {
             icon: <FaXTwitter />,
-            platform: "X (Twitter)",
+            platform: "(Twitter)",
             url: `https://twitter.com/intent/tweet?text=${jobText}&url=${jobUrl}`,
             className: "bg-black",
             tooltipTitle: "X'te paylaş",

--- a/components/ui/LoaderSkeleton.tsx
+++ b/components/ui/LoaderSkeleton.tsx
@@ -12,7 +12,7 @@ const LoaderSkeleton = ({
 }: {
   animationType: false | "pulse" | "wave" | undefined;
   variant: "text" | "rectangular" | "rounded" | "circular";
-  sxClass: {
+  sxClass?: {
     borderRadius: string;
     width: string;
     height: string;
@@ -32,9 +32,9 @@ const LoaderSkeleton = ({
       animation={animationType}
       variant={variant}
       sx={{
-        borderRadius: sxClass.borderRadius,
-        width: sxClass.width,
-        height: sxClass.height,
+        borderRadius: sxClass?.borderRadius,
+        width: sxClass?.width,
+        height: sxClass?.height,
         ...extraSxClass,
       }}
     />

--- a/types/auth/employer/open-jobs.types.ts
+++ b/types/auth/employer/open-jobs.types.ts
@@ -30,6 +30,8 @@ export interface EmployerOpenJobs {
   additionalQuestions: JobPostingAdditionalQuestions;
   requirements: string[];
   responsibilities: string[];
+  salary: string;
+  gender: string;
 }
 
 export interface JobPostingAdditionalQuestions {


### PR DESCRIPTION
# Overview
This PR introduces the **JobOverview sidebar** with enhanced UI and better component structure.

## Changes
- Added `JobOverview` component and integrated it into the `is-ilani` route.  
- Created `icons.ts` and `sidebar.types.ts` for reusable types & icons.  
- Extended `EmployerOpenJobs` interface with `salary` and `gender` fields.  
- Introduced `List` and `ListItem` components for displaying overview data.  
- Made `LoaderSkeleton`'s `sxClass` prop optional.  
- Refined styles for `JobAbout`, `DesktopShareLinks`, and `ShareDesktop` for consistency.  

## Notes
- Ensures better UI/UX with a cleaner sidebar layout.  
- Improves reusability of types and components.  
- Prepares codebase for further job-related features.  