### PR TITLE
Add JobSkills component to job detail page

### DIFF
--- a/app/is-ilani/page.tsx
+++ b/app/is-ilani/page.tsx
@@ -43,6 +43,11 @@ const JobOverview = dynamic(
   { ssr: false }
 );
 
+const JobSkills = dynamic(
+  () => import("@/components/pages/jobDetail/JobAbout/JobSkills/JobSkills"),
+  { ssr: false }
+);
+
 const JobDetail = () => {
   const params = useSearchParams();
   const { data, isLoading } = useGetJobDetailQuery({
@@ -188,6 +193,17 @@ const JobDetail = () => {
               variant="rounded"
               animationType="pulse"
               className="w-full !h-[250px] !rounded-lg"
+            />
+          )}
+
+          {data?.job && (
+            <JobSkills
+              skills={[
+                data?.job.category,
+                data?.job.positionLevel,
+                data?.job.modeOfWork,
+                data?.job.experienceTime,
+              ]}
             />
           )}
         </div>

--- a/components/pages/jobDetail/JobAbout/JobSkills/JobSkills.tsx
+++ b/components/pages/jobDetail/JobAbout/JobSkills/JobSkills.tsx
@@ -1,0 +1,75 @@
+import { CAREER_LEVELS, JOB_TYPES } from "@/constants/filtersJob";
+import useJobFilter from "@/hooks/useJobFilter";
+import useScroll from "@/hooks/useScroll";
+import {
+  clearAllFilters,
+  selectCareerLevel,
+  selectExperienceLevel,
+  selectFiltersItem,
+  selectJobKeyword,
+  selectJobType,
+} from "@/lib/redux/features/filterJobs/filters";
+import { useRouter } from "next/navigation";
+import React from "react";
+import { useDispatch } from "react-redux";
+
+const JobSkills = ({ skills }: { skills: string[] }) => {
+  const { filterJob } = useJobFilter();
+  const dispatch = useDispatch();
+  const router = useRouter();
+  const { applyScroll } = useScroll();
+
+  const handleItemFilter = (text: string) => {
+    const isIncludesExperience = text.includes("Yıl");
+
+    const isFindCareerLevel = CAREER_LEVELS.find((val) =>
+      text.includes(val.itemText)
+    )?.itemText;
+
+    const isFindJobType = JOB_TYPES.find((val) => text.includes(val));
+
+    dispatch(clearAllFilters());
+
+    if (isIncludesExperience) dispatch(selectExperienceLevel([text]));
+
+    if (isFindJobType) dispatch(selectJobType(isFindJobType));
+
+    if (isFindCareerLevel || text.includes("Düzey")) {
+      dispatch(selectCareerLevel([text || (isFindCareerLevel as string)]));
+    }
+
+    if (!isFindCareerLevel && !isIncludesExperience) {
+      dispatch(selectJobKeyword([text]));
+    }
+
+    filterJob();
+    router.push("/is-ilanlari");
+    dispatch(selectFiltersItem([text]));
+    setTimeout(() => applyScroll(640, 474.57, 386.63), 400);
+  };
+
+  return (
+    <div className="mt-[30px] bg-[#f5f7fc] p-[30px] max-[992px]:p-5 rounded-lg">
+      <h2 className="text-lg text-[#202124] font-medium mb-[18px]">
+        Pozisyon Bilgileri
+      </h2>
+
+      <ul className="flex flex-wrap gap-1.5">
+        {skills.map((val, i) => (
+          <li
+            key={i}
+            className="bg-white hover:bg-black text-[#696969] hover:text-white transition-colors duration-500 py-[3px] px-5 rounded-sm text-sm cursor-pointer"
+            onClick={() => handleItemFilter(val)}
+          >
+            {val.includes("Yıl")
+              ? `${val} Deneyim`
+              : !JOB_TYPES.includes(val) && val}
+            {JOB_TYPES.includes(val) ? `${val} Çalışma` : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default JobSkills;


### PR DESCRIPTION
### Overview
This PR introduces the `JobSkills` component to the job detail page (`is-ilani`) to display key job information:

- Category
- Position Level
- Mode of Work
- Experience Time

### Changes
- Created `JobSkills` component with clickable filters.
- Integrated `JobSkills` into the job detail page using dynamic import for lazy loading.
- Connected component to Redux store to handle filter state and routing.

### Notes
- Ensures interactive filtering for job skills.
- Ready for further enhancements if additional job filters are added.