### PR TITLE
fix(api): correct slug param type in employers route

### DIFF
--- a/app/api/firebase/employers/[slug]/route.ts
+++ b/app/api/firebase/employers/[slug]/route.ts
@@ -5,7 +5,7 @@ import { Employer } from "@/types/auth/models/employer";
 
 export async function GET(
   _request: Request,
-  { params }: { params: Promise<{ slug: string[] }> }
+  { params }: { params: Promise<{ slug: string }> }
 ) {
   const { slug } = await params;
 


### PR DESCRIPTION
Fixes a type mismatch in the GET /api/firebase/employers/[slug] endpoint.

Changes:
- Updated params type from `Promise<{ slug: string[] }>` to `Promise<{ slug: string }>`
- Awaited the params correctly to extract the slug
- Ensures Netlify build succeeds without type errors

This resolves the following type error during build:
Type '{ slug: string; }' is not assignable to type '{ slug: string[]; }'.
