### PR TITLE
Enable candidate profile updates in dashboard

### DIFF
--- a/app/(dashboard)/pages/Profile/ProfileForm/CandidateForm.tsx
+++ b/app/(dashboard)/pages/Profile/ProfileForm/CandidateForm.tsx
@@ -9,7 +9,7 @@ import { formatTurkishPhoneNumber } from "@/lib/formatPhoneNumber";
 import cities from "@/data/cities";
 
 // formik and schema
-import { Form, Formik, FormikHelpers } from "formik";
+import { Form, Formik } from "formik";
 import { candidateFormSchema } from "./schema/CandidateFormSchema";
 
 // dayjs
@@ -20,10 +20,16 @@ import "dayjs/locale/tr";
 import DatePicker, { registerLocale } from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { tr } from "date-fns/locale/tr";
-import { CandidateForm as CandidateFormInterface } from "./types";
-import { useDispatch } from "react-redux";
-import { setProfileImage } from "@/lib/redux/features/dashboard/userDashboardSlice";
 registerLocale("tr", tr);
+
+import { CandidateForm as CandidateFormInterface } from "./types";
+
+// lib
+import { setProfileImage } from "@/lib/redux/features/dashboard/userDashboardSlice";
+import { useUpdateProfileMutation } from "@/lib/redux/services/dashboard/candidateProfileApi";
+import { CircularProgress } from "@mui/material";
+import { useDispatch } from "react-redux";
+import toast from "react-hot-toast";
 
 const CandidateForm = () => {
   const { user } = useContext(AuthContext);
@@ -34,12 +40,43 @@ const CandidateForm = () => {
   const dispatch = useDispatch();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [imageFile, setImageFile] = useState<File>();
+  const [updateProfile] = useUpdateProfileMutation();
 
-  const onSubmit = (
-    values: CandidateFormInterface,
-    actions: FormikHelpers<CandidateFormInterface>
-  ) => {
-    actions.resetForm();
+  const onSubmit = async (values: CandidateFormInterface) => {
+    try {
+      const filledFields = Object.fromEntries(
+        Object.entries(values).filter(([, v]) => v)
+      ) as CandidateFormInterface;
+
+      if (user) {
+        const { dateOfBirth } = currentUser;
+
+        const isChange = [
+          "name",
+          "email",
+          "gender",
+          "age",
+          "phoneNumber",
+          "title",
+          "city",
+        ].some((val) => {
+          const value = val as keyof typeof isChange;
+
+          return currentUser[value] !== filledFields[value];
+        });
+
+        if (isChange || dateOfBirth !== startDate) {
+          await updateProfile({
+            userId: String(user?.id),
+            data: { ...filledFields, dateOfBirth: startDate as Date },
+          }).unwrap();
+        }
+      }
+    } catch {
+      toast.error("Profiliniz güncellenemedi tekrar deneyin", {
+        position: "bottom-right",
+      });
+    }
   };
 
   const handleChangeImage = (e: ChangeEvent<HTMLInputElement>) => {
@@ -55,7 +92,7 @@ const CandidateForm = () => {
   return (
     <Formik
       initialValues={{
-        fullname: user?.name ?? "",
+        name: user?.name ?? "",
         email: user?.email ?? "",
         gender: currentUser?.gender ?? "",
         age: currentUser?.age ?? "",
@@ -80,19 +117,19 @@ const CandidateForm = () => {
           <div className="grid sm:grid-cols-2 gap-x-[29px] gap-y-[22px]">
             <CustomInput
               label="Ad Soyad"
-              name="fullname"
+              name="name"
               type="text"
               className="!rounded-[15px] !ps-4"
               placeholder={user?.name ?? user?.displayName}
             />
 
-            <CustomInput
+            {/* <CustomInput
               label="E-posta"
               name="email"
               type="email"
               className="!rounded-[15px] !ps-4"
               placeholder={user?.email}
-            />
+            /> */}
 
             <div className="w-full flex flex-col">
               <label className="block mb-1.5" htmlFor="date">
@@ -151,7 +188,7 @@ const CandidateForm = () => {
               name="phoneNumber"
               type="text"
               className="!rounded-[15px] !px-4"
-              value={formatTurkishPhoneNumber(values.phoneNumber)}
+              value={formatTurkishPhoneNumber(values.phoneNumber ?? "")}
               placeholder={user?.phoneNumber ?? "0555 555 5555"}
             />
 
@@ -172,7 +209,11 @@ const CandidateForm = () => {
           </div>
 
           <button className="custom__button float-right max-sm:w-full mt-[30px] !bg-[#1814F3] w-[190px] h-[50px] !rounded-[15px]">
-            Kaydet
+            {isSubmitting ? (
+              <CircularProgress size={22} color="inherit" />
+            ) : (
+              "Kaydet"
+            )}
           </button>
         </Form>
       )}

--- a/app/(dashboard)/pages/Profile/ProfileForm/schema/CandidateFormSchema.ts
+++ b/app/(dashboard)/pages/Profile/ProfileForm/schema/CandidateFormSchema.ts
@@ -1,6 +1,6 @@
 import * as Yup from "yup";
 
 export const candidateFormSchema = Yup.object().shape({
-  fullname: Yup.string().required("isim girin"),
+  name: Yup.string().required("isim girin"),
   email: Yup.string().required("e-posta girin").email("geçerli e-posta girin"),
 });

--- a/app/(dashboard)/pages/Profile/ProfileForm/types.ts
+++ b/app/(dashboard)/pages/Profile/ProfileForm/types.ts
@@ -1,5 +1,5 @@
 export interface CandidateForm {
-  fullname: string;
+  name: string;
   email: string;
   gender: string;
   age: string;

--- a/app/api/dashboard/update-candidate-profile/[userId]/route.ts
+++ b/app/api/dashboard/update-candidate-profile/[userId]/route.ts
@@ -1,0 +1,27 @@
+import { db } from "@/app/api/firebase/firebaseConfig";
+
+import { doc, setDoc } from "firebase/firestore";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const { userId } = await params;
+  const body = await req.json();
+
+  const sanitizationData = Object.fromEntries(
+    Object.entries(body).filter(([, v]) => v)
+  );
+
+  const userRef = doc(db, "users", userId);
+
+  await setDoc(userRef, sanitizationData, {
+    merge: true,
+  });
+
+  return NextResponse.json(
+    { message: "Profile successfully updated" },
+    { status: 200 }
+  );
+}

--- a/lib/redux/services/dashboard/candidateProfileApi.ts
+++ b/lib/redux/services/dashboard/candidateProfileApi.ts
@@ -1,0 +1,23 @@
+import { CandidateForm } from "@/app/(dashboard)/pages/Profile/ProfileForm/types";
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+export const candidateProfileApi = createApi({
+  reducerPath: "candidateProfileApi",
+  baseQuery: fetchBaseQuery({
+    baseUrl: "/api/dashboard/update-candidate-profile/",
+  }),
+  endpoints: (builder) => ({
+    updateProfile: builder.mutation<
+      { message: string },
+      { userId: string; data: CandidateForm & { dateOfBirth: Date } }
+    >({
+      query: ({ userId, data }) => ({
+        method: "POST",
+        url: `${userId}`,
+        body: data,
+      }),
+    }),
+  }),
+});
+
+export const { useUpdateProfileMutation } = candidateProfileApi;

--- a/lib/redux/store.ts
+++ b/lib/redux/store.ts
@@ -21,6 +21,7 @@ import { GeocodeApi } from "./services/geocodeApi";
 import { userDashboardSlice } from "./features/dashboard/userDashboardSlice";
 import { candidateStaticsApi } from "./services/dashboard/candidateStaticsApi";
 import { userViewsApi } from "./services/dashboard/userViewsApi";
+import { candidateProfileApi } from "./services/dashboard/candidateProfileApi";
 
 export const store = configureStore({
   reducer: {
@@ -45,6 +46,7 @@ export const store = configureStore({
     [GeocodeApi.reducerPath]: GeocodeApi.reducer,
     [candidateStaticsApi.reducerPath]: candidateStaticsApi.reducer,
     [userViewsApi.reducerPath]: userViewsApi.reducer,
+    [candidateProfileApi.reducerPath]: candidateProfileApi.reducer,
   },
 
   middleware: (getDefaultMiddleware) =>
@@ -59,6 +61,7 @@ export const store = configureStore({
       GeocodeApi.middleware,
       candidateStaticsApi.middleware,
       userViewsApi.middleware,
+      candidateProfileApi.middleware,
     ]),
 });
 


### PR DESCRIPTION
This PR adds the ability for candidates to update their profile information directly from the dashboard.

Changes include:
- Created a dynamic API route (`update-candidate-profile`) to handle candidate profile updates
- Integrated RTK Query mutation (`useUpdateProfileMutation`) for seamless API requests
- Updated `CandidateForm` to use the mutation and handle form submission with validation
- Added loading state handling and improved user feedback on successful or failed updates

This feature ensures that users can keep their profile information up-to-date without leaving the dashboard interface.