### PR TITLE
feat(backend): add request validation middleware

### DIFF
--- a/backend/src/shared/middlewares/validateRequest.ts
+++ b/backend/src/shared/middlewares/validateRequest.ts
@@ -1,0 +1,20 @@
+import { NextFunction, Request, Response } from "express";
+import z, { ZodType } from "zod";
+
+export const validateRequest =
+  (schema: ZodType, property: "body" | "query" | "params" = "body") =>
+  (req: Request, res: Response, next: NextFunction) => {
+    try {
+      schema.parse(req[property]);
+      next();
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json(
+          error.issues.map(({ message, path }) => {
+            return { message, path: path.at(0) };
+          })
+        );
+      }
+      next(error);
+    }
+  };


### PR DESCRIPTION
## Overview
Added a `validateRequest` middleware to handle schema validation for incoming requests.  
Uses Zod to validate `body`, `query`, or `params`, returning consistent 400 responses for invalid inputs.

## Changes
- Created `validateRequest` middleware in `shared/middlewares/validateRequest.ts`
- Supports any Zod schema and request property (`body` | `query` | `params`)
- Returns a JSON array of validation errors with `message` and `path` for each issue

## Example Response
```json
[
  { "message": "Name is required", "path": "name" },
  { "message": "Email must be valid", "path": "email" }
]
```

## Notes

- If a request passes validation, it proceeds to the next middleware/route handler
- Errors are caught and returned with status 400
- Other non-validation errors are forwarded to the global error handle