### PR TITLE
feat: add social media link management to employer profile (frontend)

### DIFF
--- a/frontend/features/dashboard/constants/social.constants.ts
+++ b/frontend/features/dashboard/constants/social.constants.ts
@@ -1,0 +1,15 @@
+export const SOCIAL_PLATFORMS = [
+  "LinkedIn",
+  "GitHub",
+  "GitLab",
+  "X (Twitter)",
+  "Facebook",
+  "Instagram",
+  "YouTube",
+  "TikTok",
+  "Medium",
+  "Discord",
+  "Telegram",
+  "Reddit",
+  "Pinterest",
+];

--- a/frontend/features/dashboard/employer/Profile/EmployerProfile.tsx
+++ b/frontend/features/dashboard/employer/Profile/EmployerProfile.tsx
@@ -10,6 +10,7 @@ import CategoryInput from "./Category/CategoryInput";
 import MarkdownEditor from "@/shared/components/MarkdownEditor";
 import useProfileForm from "./useProfileForm";
 import CustomButton from "@/shared/components/ui/CustomButton";
+import Social from "./Socials/Social";
 
 const EmployerProfile = () => {
   const { user } = useContext(AuthContext);
@@ -120,6 +121,8 @@ const EmployerProfile = () => {
           </form>
         </FormProvider>
       </Profile>
+
+      <Social />
 
       <CustomButton
         type="submit"

--- a/frontend/features/dashboard/employer/Profile/Socials/Social.tsx
+++ b/frontend/features/dashboard/employer/Profile/Socials/Social.tsx
@@ -1,0 +1,67 @@
+import CustomButton from "@/shared/components/ui/CustomButton";
+import SocialList from "./SocialList";
+import { useDispatch, useSelector } from "react-redux";
+import { AppDispatch, RootState } from "@/shared/redux/store";
+import { setPlatform } from "./social-slice";
+
+const Social = () => {
+  const { selectedPlatform } = useSelector(
+    (state: RootState) => state.socialSlice,
+  );
+  const dispatch = useDispatch<AppDispatch>();
+
+  return (
+    <div className="mt-5 bg-white py-[37px] px-[30px] rounded-[25px]">
+      <h2 className="mb-[25px] text-[#202124] font-medium text-lg">
+        Sosyal Ağlar
+      </h2>
+
+      {selectedPlatform.length ? (
+        selectedPlatform.map((val, index) => (
+          <SocialList key={index} index={val.id} />
+        ))
+      ) : (
+        <div className="text-center">
+          <p className="mb-[25px] text-slate-600">
+            🔗 Profilini güçlendirmek için sosyal medya bağlantılarını
+            ekleyebilirsin.
+          </p>
+
+          <CustomButton
+            type="button"
+            text="Bağlantı ekle"
+            className="!bg-[#EFF4FC] hover:!bg-[#DDE8F8] !text-[#1967d2] text-[15px] !rounded-lg !py-[15px] !px-[30px] mt-[5px]"
+            handleClick={() =>
+              dispatch(
+                setPlatform({
+                  id: selectedPlatform.length + 1,
+                  url: "",
+                  platform: "Facebook",
+                }),
+              )
+            }
+          />
+        </div>
+      )}
+
+      {selectedPlatform.length ? (
+        <CustomButton
+          type="button"
+          text="Başka Bir Ağ Ekle"
+          className="!bg-[#EFF4FC] hover:!bg-[#DDE8F8] !text-[#1967d2] text-[15px] !rounded-lg !py-[15px] !px-[30px] mt-[5px]"
+          handleClick={() =>
+            dispatch(
+              setPlatform({
+                id: selectedPlatform.length + 1,
+                url: "",
+                platform: "Facebook",
+              }),
+            )
+          }
+        />
+      ) : null}
+    </div>
+  );
+};
+
+export default Social;

--- a/frontend/features/dashboard/employer/Profile/Socials/SocialList.tsx
+++ b/frontend/features/dashboard/employer/Profile/Socials/SocialList.tsx
@@ -1,0 +1,163 @@
+import CustomButton from "@/shared/components/ui/CustomButton";
+import CustomInput from "@/shared/components/ui/CustomInput";
+import { FiChevronDown } from "react-icons/fi";
+import { IoClose } from "react-icons/io5";
+import SocialPlatformItem from "./SocialPlatformItem";
+import { useDispatch, useSelector } from "react-redux";
+import { AppDispatch, RootState } from "@/shared/redux/store";
+import {
+  removePlatform,
+  setActiveSocialPlatformId,
+  updatePlatformUrl,
+} from "./social-slice";
+import { useEffect, useState } from "react";
+import { SOCIAL_PLATFORMS } from "@/features/dashboard/constants/social.constants";
+
+const SocialList = ({ index }: { index: number }) => {
+  const { selectedPlatform, activeSocialPlatformId } = useSelector(
+    (state: RootState) => state.socialSlice,
+  );
+  const dispatch = useDispatch<AppDispatch>();
+  const findPlatform = selectedPlatform.find(({ id }) => id === index);
+  const [toggleMenu, setToggleMenu] = useState(false);
+  const [searchPlatform, setSearchPlatform] = useState("");
+  const filtersPlatform = SOCIAL_PLATFORMS.filter((item) =>
+    item.toLowerCase().includes(searchPlatform.toLowerCase()),
+  );
+
+  useEffect(() => {
+    const close = () => dispatch(setActiveSocialPlatformId(0));
+    window.addEventListener("click", close);
+    return () => window.removeEventListener("click", close);
+  }, [dispatch]);
+
+  const handleToggleMenu = () => setToggleMenu(!toggleMenu);
+
+  return (
+    <ul className="mb-5">
+      <li
+        className="flex items-center justify-between bg-[#f0f5f7] py-5 px-3 rounded-lg text-sm w-full cursor-pointer font-medium"
+        onClick={handleToggleMenu}
+      >
+        <div className="flex items-center gap-x-1.5">
+          <CustomButton
+            className="!p-0 !bg-transparent !text-[#a00] hover:!text-[#e44343]"
+            handleClick={() => dispatch(removePlatform(index))}
+          >
+            <IoClose />
+          </CustomButton>
+
+          <span>Bağlantı {index}</span>
+        </div>
+
+        <button>
+          <FiChevronDown
+            className={`transform ${!toggleMenu ? "rotate-180" : "rotate-0"} `}
+          />
+        </button>
+      </li>
+
+      {!toggleMenu && (
+        <div className="flex flex-col">
+          <ul className="mt-[15px] flex flex-col gap-y-[15px]">
+            <li className="flex items-center justify-between">
+              <span className="text-[#202124] text-[15px] font-semibold flex-[15%]">
+                Bağlantı
+              </span>
+
+              <div className="flex-[85%] relative select-none">
+                <div
+                  className="bg-[#f0f5f7] py-5 ps-5 pe-3 rounded-lg text-sm text-[#696969] flex items-center justify-between cursor-pointer"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    dispatch(setActiveSocialPlatformId(index));
+                  }}
+                >
+                  {findPlatform?.platform ?? "Facebook"}
+                  <FiChevronDown
+                    className={`transform ${activeSocialPlatformId === index ? "rotate-180" : "rotate-0"}`}
+                  />
+                </div>
+
+                {activeSocialPlatformId === index && (
+                  <div
+                    className="absolute top-full w-full bg-white py-5 border border-[#ECEDF2] rounded-lg flex flex-col gap-y-1.5 text-slate-600 text-sm z-10"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <CustomInput
+                      className="!rounded-lg !px-5 !py-[8px] text-[15px] mb-3 mx-[25px] !w-[95%]"
+                      onChange={(e) => setSearchPlatform(e.target.value)}
+                      value={searchPlatform}
+                    />
+
+                    <ul className="max-h-[200px] visible-scrollbar flex flex-col gap-y-1.5">
+                      {!searchPlatform.length &&
+                        SOCIAL_PLATFORMS.map((platform) => (
+                          <SocialPlatformItem
+                            key={platform}
+                            defaultPlatform={
+                              findPlatform?.platform ?? "Facebook"
+                            }
+                            platform={platform}
+                            index={index}
+                            setSearchPlatform={setSearchPlatform}
+                          />
+                        ))}
+
+                      {filtersPlatform.length ? (
+                        filtersPlatform.map((platform) => (
+                          <SocialPlatformItem
+                            key={platform}
+                            defaultPlatform={
+                              findPlatform?.platform ?? "Facebook"
+                            }
+                            platform={platform}
+                            index={index}
+                            setSearchPlatform={setSearchPlatform}
+                          />
+                        ))
+                      ) : (
+                        <span className="px-[25px] inline-block">
+                          Sonuç Bulunamadı.
+                        </span>
+                      )}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            </li>
+
+            <li className="flex items-center justify-between">
+              <span className="text-[#202124] text-[15px] font-semibold flex-[15%]">
+                URL
+              </span>
+
+              <div className="flex-[85%]">
+                <CustomInput
+                  className="!rounded-lg !py-[19px] !px-5 text-slate-600 placeholder:text-slate-400"
+                  placeholder="Profil bağlantısını girin"
+                  onChange={(e) => {
+                    dispatch(
+                      updatePlatformUrl({
+                        updateId: index,
+                        url: e.target.value,
+                      }),
+                    );
+                  }}
+                />
+              </div>
+            </li>
+          </ul>
+
+          <CustomButton
+            text="Ağı Kaldır"
+            className="!bg-[#EFF4FC] hover:!bg-[#DDE8F8] !text-[#1967d2] self-end text-[15px] !rounded-lg !py-2.5 !px-5 mt-[25px]"
+            handleClick={() => dispatch(removePlatform(index))}
+          />
+        </div>
+      )}
+    </ul>
+  );
+};
+
+export default SocialList;

--- a/frontend/features/dashboard/employer/Profile/Socials/SocialPlatformItem.tsx
+++ b/frontend/features/dashboard/employer/Profile/Socials/SocialPlatformItem.tsx
@@ -1,0 +1,44 @@
+import { AppDispatch, RootState } from "@/shared/redux/store";
+import { useDispatch, useSelector } from "react-redux";
+import { setActiveSocialPlatformId, setPlatform } from "./social-slice";
+
+const SocialPlatformItem = ({
+  defaultPlatform,
+  platform,
+  index,
+  setSearchPlatform,
+}: {
+  defaultPlatform: string;
+  platform: string;
+  index: number;
+  setSearchPlatform: React.Dispatch<React.SetStateAction<string>>;
+}) => {
+  const { selectedPlatform } = useSelector(
+    (state: RootState) => state.socialSlice,
+  );
+  const dispatch = useDispatch<AppDispatch>();
+  const isIncludePlatform = selectedPlatform.some(
+    (item) => item.id === index && item.platform === platform,
+  );
+
+  const handleSelectPlatform = () => {
+    dispatch(setPlatform({ id: index, url: "", platform }));
+    dispatch(setActiveSocialPlatformId(0));
+    setSearchPlatform("");
+  };
+
+  return (
+    <li
+      className={`
+        py-1.5 px-[25px] cursor-pointer hover:text-[#1967D2]  
+        ${isIncludePlatform ? "text-[#1967D2]" : ""} 
+        ${defaultPlatform === "Facebook" && platform === "Facebook" ? "text-[#1967D2]" : ""}
+      `}
+      onClick={handleSelectPlatform}
+    >
+      {platform}
+    </li>
+  );
+};
+
+export default SocialPlatformItem;

--- a/frontend/features/dashboard/employer/Profile/Socials/social-slice.ts
+++ b/frontend/features/dashboard/employer/Profile/Socials/social-slice.ts
@@ -1,0 +1,72 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+interface initialState {
+  selectedPlatform: { id: number; platform: string; url: string }[];
+  activeSocialPlatformId: number;
+}
+
+export const initialState: initialState = {
+  selectedPlatform: [],
+  activeSocialPlatformId: 0,
+};
+
+export const socialSlice = createSlice({
+  name: "socialSlice",
+  initialState,
+  reducers: {
+    setPlatform: (
+      state,
+      action: PayloadAction<{ id: number; url: string; platform: string }>,
+    ) => {
+      const payload = action.payload;
+      const index = state.selectedPlatform.findIndex(
+        (item) => item.id === payload.id,
+      );
+
+      if (index !== -1) {
+        state.selectedPlatform[index].platform = payload.platform;
+      } else {
+        state.selectedPlatform.push(payload);
+      }
+    },
+
+    removePlatform: (state, action: PayloadAction<number>) => {
+      const removeId = action.payload;
+
+      state.selectedPlatform = state.selectedPlatform
+        .filter(({ id }) => id !== removeId)
+        .map((item) => ({
+          ...item,
+          id: item.id > removeId ? item.id - 1 : item.id,
+        }));
+    },
+
+    updatePlatformUrl: (
+      state,
+      action: PayloadAction<{ updateId: number; url: string }>,
+    ) => {
+      const { updateId, url } = action.payload;
+
+      state.selectedPlatform = state.selectedPlatform.map((item) =>
+        item.id === updateId ? { ...item, url } : item,
+      );
+    },
+
+    setActiveSocialPlatformId: (state, action: PayloadAction<number>) => {
+      const platformId = action.payload;
+
+      if (state.activeSocialPlatformId !== platformId) {
+        state.activeSocialPlatformId = platformId;
+      } else {
+        state.activeSocialPlatformId = 0;
+      }
+    },
+  },
+});
+
+export const {
+  setPlatform,
+  removePlatform,
+  updatePlatformUrl,
+  setActiveSocialPlatformId,
+} = socialSlice.actions;

--- a/frontend/shared/redux/store.ts
+++ b/frontend/shared/redux/store.ts
@@ -28,6 +28,7 @@ import { jobApi } from "@/features/dashboard/employer/services/jobApi";
 import { jobsApi } from "@/features/jobs/postings/services/jobsApi";
 import { paginationSlice } from "@/features/jobs/postings/components/pagination/paginationSlice";
 import { filtersSlice } from "./slices/filtersData";
+import { socialSlice } from "@/features/dashboard/employer/Profile/Socials/social-slice";
 
 export const store = configureStore({
   reducer: {
@@ -45,6 +46,7 @@ export const store = configureStore({
     resumeSlice: resumeSlice.reducer,
     paginationSlice: paginationSlice.reducer,
     filtersSlice: filtersSlice.reducer,
+    socialSlice: socialSlice.reducer,
     [featuredJobsApi.reducerPath]: featuredJobsApi.reducer,
     [bestCompaniesApi.reducerPath]: bestCompaniesApi.reducer,
     [favoritesApi.reducerPath]: favoritesApi.reducer,


### PR DESCRIPTION
## Overview
This pull request introduces a frontend-only social media link management feature
for employer profiles, allowing employers to add, update, and remove social platform
links to enhance profile visibility.

## Scope of Changes
- Implemented social media management UI for employer profiles
- Added Redux state to handle selected platforms, active dropdowns, and URLs
- Integrated the social section into the existing employer profile page
- Improved UX with contextual placeholders and consistent input styling

## Current Limitations
- This implementation is frontend-only
- Social media links are currently not persisted to the backend
- Data will be reset on page refresh

## Future Work
- Backend API integration for persistence
- Server-side validation for social media URLs
- Pre-populating social links from user profile data

## Impact
- Improves employer profile completeness and presentation
- Establishes a solid frontend foundation for future backend integration
- No changes to existing backend contracts

## Risk Assessment
- No breaking changes
- Scoped only to employer profile UI and Redux state
- Existing profile functionality remains unaffected

## Validation
- Manually tested all add, update, and remove flows
- Verified empty and populated states render correctly
- Confirmed no impact on existing profile functionality